### PR TITLE
[feat/#17] TourCheckView UI, CustomButton 구현

### DIFF
--- a/Roomie/Roomie/Global/Components/CustomButton.swift
+++ b/Roomie/Roomie/Global/Components/CustomButton.swift
@@ -1,0 +1,84 @@
+//
+//  CustomButton.swift
+//  Roomie
+//
+//  Created by 김승원 on 1/11/25.
+//
+
+import UIKit
+
+/// primaryPurple 색상의 버튼 컴포넌트입니다.
+///
+/// 초기화 시 버튼 타이틀과 활성화 상태를 설정할 수 있습니다.
+/// isEnabled값에 따라 배경색상을 설정합니다.
+///
+/// - Parameters:
+///     - title: 버튼 제목을 나타내는 문자열입니다.
+///     - isEnabled: 버튼 활성화 여부입니다. 디폴트값은 true입니다.
+final class CustomButton: UIButton {
+    
+    // MARK: - Property
+    
+    static let defaultHeight: CGFloat = Screen.height(58)
+    
+    override var isEnabled: Bool {
+        didSet {
+            updateButtonColor()
+        }
+    }
+    
+    // MARK: - Initializer
+    
+    init(title: String, isEnabled: Bool = true) {
+        super.init(frame: .zero)
+        
+        setButton(with: title, isEnabled: isEnabled)
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setButton()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        setButton()
+    }
+}
+
+// MARK: - Function
+
+private extension CustomButton {
+    func setButton(with title: String = " ", isEnabled: Bool = true) {
+        setTitle(title, style: .title2, color: .grayscale1)
+        self.isEnabled = isEnabled
+        layer.cornerRadius = 8
+        
+        addTarget(
+            self,
+            action: #selector(buttonPressed),
+            for: .touchDown
+        )
+        addTarget(
+            self,
+            action: #selector(buttonReleased),
+            for: [.touchUpInside,.touchUpOutside,.touchCancel]
+        )
+    }
+    
+    func updateButtonColor() {
+        backgroundColor = isEnabled ? .primaryPurple : .grayscale6
+    }
+    
+    @objc
+    func buttonPressed() {
+        backgroundColor = .primaryLight1
+    }
+    
+    @objc
+    func buttonReleased() {
+        updateButtonColor()
+    }
+}

--- a/Roomie/Roomie/Presentation/Tour/View/TourCheckView.swift
+++ b/Roomie/Roomie/Presentation/Tour/View/TourCheckView.swift
@@ -21,6 +21,8 @@ final class TourCheckView: BaseView {
     
     private let roomTitleLabel = UILabel()
     let roomNameLabel = UILabel()
+    
+    let nextButton = CustomButton(title: "이 방이 맞아요")
         
     
     // MARK: - UISetting
@@ -55,7 +57,8 @@ final class TourCheckView: BaseView {
             houseTitleLabel,
             houseNameLabel,
             roomTitleLabel,
-            roomNameLabel
+            roomNameLabel,
+            nextButton
         )
     }
     
@@ -87,6 +90,12 @@ final class TourCheckView: BaseView {
             $0.top.equalTo(houseNameLabel.snp.bottom).offset(16)
             $0.leading.equalTo(roomTitleLabel.snp.trailing).offset(20)
             $0.trailing.equalToSuperview().inset(20)
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).offset(-12)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(58)
         }
     }
 }

--- a/Roomie/Roomie/Presentation/Tour/View/TourCheckView.swift
+++ b/Roomie/Roomie/Presentation/Tour/View/TourCheckView.swift
@@ -24,7 +24,6 @@ final class TourCheckView: BaseView {
     
     let nextButton = CustomButton(title: "이 방이 맞아요")
         
-    
     // MARK: - UISetting
     
     override func setStyle() {

--- a/Roomie/Roomie/Presentation/Tour/View/TourCheckView.swift
+++ b/Roomie/Roomie/Presentation/Tour/View/TourCheckView.swift
@@ -1,0 +1,92 @@
+//
+//  TourCheckView.swift
+//  Roomie
+//
+//  Created by 김승원 on 1/11/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class TourCheckView: BaseView {
+    
+    // MARK: - UIComponent
+    
+    let titleLabel = UILabel()
+    
+    private let houseTitleLabel = UILabel()
+    let houseNameLabel = UILabel()
+    
+    private let roomTitleLabel = UILabel()
+    let roomNameLabel = UILabel()
+        
+    
+    // MARK: - UISetting
+    
+    override func setStyle() {
+        titleLabel.do {
+            $0.setText("선택하신 방이 맞는지\n확인해주세요", style: .heading2, color: .grayscale12)
+            $0.textAlignment = .left
+        }
+        
+        houseTitleLabel.do {
+            $0.setText("신청지점", style: .body2, color: .grayscale7)
+        }
+        
+        houseNameLabel.do {
+            $0.setText("해피쉐어 100호점 (건대점)", style: .body1, color: .grayscale12)
+        }
+        
+        roomTitleLabel.do {
+            $0.setText("대상", style: .body2, color: .grayscale7)
+        }
+        
+        roomNameLabel.do {
+            $0.setText("1A (싱글침대)", style: .body1, color: .grayscale12)
+        }
+    }
+    
+    override func setUI() {
+        backgroundColor = .grayscale1 // TODO: 화면 연결 후 삭제
+        addSubviews(
+            titleLabel,
+            houseTitleLabel,
+            houseNameLabel,
+            roomTitleLabel,
+            roomNameLabel
+        )
+    }
+    
+    override func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(24)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        houseTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(52)
+            $0.leading.equalToSuperview().inset(20)
+            $0.width.equalTo(52)
+        }
+        
+        houseNameLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(52)
+            $0.leading.equalTo(houseTitleLabel.snp.trailing).offset(20)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+        
+        roomTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(houseTitleLabel.snp.bottom).offset(16)
+            $0.leading.equalToSuperview().inset(20)
+            $0.width.equalTo(52)
+        }
+        
+        roomNameLabel.snp.makeConstraints {
+            $0.top.equalTo(houseNameLabel.snp.bottom).offset(16)
+            $0.leading.equalTo(roomTitleLabel.snp.trailing).offset(20)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+    }
+}

--- a/Roomie/Roomie/Presentation/Tour/View/TourCheckView.swift
+++ b/Roomie/Roomie/Presentation/Tour/View/TourCheckView.swift
@@ -95,7 +95,7 @@ final class TourCheckView: BaseView {
         nextButton.snp.makeConstraints {
             $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).offset(-12)
             $0.horizontalEdges.equalToSuperview().inset(20)
-            $0.height.equalTo(58)
+            $0.height.equalTo(CustomButton.defaultHeight)
         }
     }
 }

--- a/Roomie/Roomie/Presentation/Tour/ViewController/TourCheckViewController.swift
+++ b/Roomie/Roomie/Presentation/Tour/ViewController/TourCheckViewController.swift
@@ -1,0 +1,30 @@
+//
+//  TourCheckViewController.swift
+//  Roomie
+//
+//  Created by 김승원 on 1/11/25.
+//
+
+import UIKit
+import Combine
+
+import CombineCocoa
+
+final class TourCheckViewController: BaseViewController {
+    
+    // MARK: - Property
+    
+    private let rootView = TourCheckView()
+
+    // MARK: - LifeCycle
+    
+    override func loadView() {
+        view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupNavigationBar(with: "", isBorderHidden: true)
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #17 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- TourCheckView의 UI를 구현하였습니다.

|    구현 내용    |   iPhone 13 mini   | iPhone 16 Pro |
| :-------------: | :----------: | :----------: |
| TourCheckView UI | <img src = "https://github.com/user-attachments/assets/977d0cc3-c036-43a8-b18e-7441193636dd" width ="250"> | <img src = "https://github.com/user-attachments/assets/fb786011-704a-40ba-abc4-e5830dd65d4a" width = "250" >
| Custom Button | <img src = "https://github.com/user-attachments/assets/8d6f82c6-f59d-4071-aead-3a060bf94738" width ="250"> | <img src = "https://github.com/user-attachments/assets/2cffbda1-9b3e-4f0b-9e46-3810d2a3f472" width = "250" >

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 설명할 코드 주제 또는 기능

- Custom Button을 추가했습니다.
- isEnabled값에 따른 배경색 처리도 구현하였습니다.
- pressed상태 배경색 처리도 구현하였습니다.
- 아래와 같이 사용하면 됩니다.

```swift
let nextButton = CustomButton(title: "이 방이 맞아요")
```

- 버튼 활성화 여부 기본값은 true이므로, 따로 처리가 필요하면 아래와 같이 사용하면 됩니다.
```swift
let nextButton = CustomButton(title: "이 방이 맞아요", isEnabled: false)
```

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

버튼의 bottom을 safeAreaLayoutGuide.bottom에 잡고, offset값을 피그마와 동일하게 주었는데,
하단바에서부터 버튼까지의 거리가 피그마랑 시뮬이랑 다르게 보이네요
피그마에 삽입되어있는 하단바 디자인이 실제 아이폰과 다른 디자인이라서 그런 걸까요..?
<img width="400" alt="스크린샷 2025-01-11 오후 11 37 52" src="https://github.com/user-attachments/assets/2f6633c1-ddbc-409b-a68d-f53662f3a16a" />

