### PR TITLE
[feat/#41] 지도 검색 뷰 구현

### DIFF
--- a/Roomie/Roomie/Global/Components/MapTextField.swift
+++ b/Roomie/Roomie/Global/Components/MapTextField.swift
@@ -1,0 +1,86 @@
+//
+//  MapTextField.swift
+//  Roomie
+//
+//  Created by 예삐 on 1/16/25.
+//
+
+import UIKit
+import Combine
+
+import CombineCocoa
+import SnapKit
+import Then
+
+/// primaryPurpler 테두리의 textField 컴포넌트입니다.
+///
+/// 초기화시 placeholder값을 설정할 수 있습니다.
+/// 입력상태시 테두리 색상이 변경됩니다.
+/// - Parameters:
+///     - placeHoder: placeHolder를 나타내는 문자열입니다.
+
+final class MapTextField: UITextField {
+    
+    // MARK: - Property
+    
+    static let defaultWidth: CGFloat = Screen.width(305)
+    static let defaultHeight: CGFloat = Screen.height(50)
+    
+    private let cancelBag = CancelBag()
+    
+    // MARK: - Initializer
+    
+    init(_ placeHolder: String = "") {
+        super.init(frame: .zero)
+        
+        setTextField(placeHolder: placeHolder)
+        setTextFieldBorder()
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setTextField()
+        setTextFieldBorder()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        setTextField()
+        setTextFieldBorder()
+    }
+}
+
+// MARK: - Functions
+
+private extension MapTextField {
+    func setTextField(placeHolder: String = "") {
+        setText(
+            placeholder: placeHolder,
+            placeholderColor: .grayscale7,
+            textColor: .grayscale12,
+            backgroundColor: .grayscale2,
+            style: .title1
+        )
+        addPadding(left: 16, right: 48)
+        setLayer(borderWidth: 1, borderColor: .grayscale5, cornerRadius: 8)
+        setAutoType()
+        
+        tintColor = .primaryPurple
+    }
+    
+    func setTextFieldBorder() {
+        let textFieldEvent = Publishers.MergeMany(
+            controlEventPublisher(for: .editingDidBegin).map { UIColor.primaryPurple.cgColor },
+            controlEventPublisher(for: .editingDidEnd).map { UIColor.grayscale5.cgColor },
+            controlEventPublisher(for: .editingDidEndOnExit).map { UIColor.grayscale5.cgColor }
+        )
+        
+        textFieldEvent
+            .sink { borderColor in
+                self.layer.borderColor = borderColor
+            }
+            .store(in: cancelBag)
+    }
+}

--- a/Roomie/Roomie/Presentation/Map/View/MapView.swift
+++ b/Roomie/Roomie/Presentation/Map/View/MapView.swift
@@ -15,9 +15,10 @@ final class MapView: BaseView {
     
     // MARK: - UIComponent
     
+    private let searchBarView = UIView()
+    private let searchBarLabel = UILabel()
     private let searchImageView = UIImageView()
-    
-    let searchTextField = UITextField()
+    let searchBarButton = UIButton()
     
     let filteringButton: UIButton = {
         var config = UIButton.Configuration.plain()
@@ -33,19 +34,20 @@ final class MapView: BaseView {
     // MARK: - UISetting
 
     override func setStyle() {
-        searchTextField.do {
-            $0.addPadding(left: 16, right: 46)
-            $0.setText(
-                placeholder: "원하는 장소를 찾아보세요",
-                placeholderColor: .grayscale7,
-                textColor: .grayscale12,
-                backgroundColor: .grayscale1,
-                style: .title1
-            )
+        searchBarView.do {
+            $0.backgroundColor = .grayscale1
             $0.layer.cornerRadius = 8
             $0.layer.shadowOpacity = 0.25
             $0.layer.shadowRadius = 2
             $0.layer.shadowOffset = CGSize(width: 0, height: 0)
+        }
+        
+        searchBarLabel.do {
+            $0.setText("원하는 장소를 찾아보세요", style: .title1, color: .grayscale7)
+        }
+        
+        searchImageView.do {
+            $0.image = .icnSearch40
         }
         
         filteringButton.do {
@@ -54,10 +56,6 @@ final class MapView: BaseView {
             $0.layer.shadowOpacity = 0.25
             $0.layer.shadowRadius = 2
             $0.layer.shadowOffset = CGSize(width: 0, height: 0)
-        }
-        
-        searchImageView.do {
-            $0.image = .icnSearch40
         }
         
         mapView.do {
@@ -78,24 +76,37 @@ final class MapView: BaseView {
         addSubviews(
             mapView,
             mapDetailCardView,
-            searchTextField,
-            filteringButton,
-            searchImageView
+            searchBarView,
+            filteringButton
+        )
+        searchBarView.addSubviews(
+            searchBarLabel,
+            searchImageView,
+            searchBarButton
         )
     }
     
     override func setLayout() {
-        searchTextField.snp.makeConstraints {
+        searchBarView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide).inset(12)
             $0.leading.equalToSuperview().inset(20)
             $0.trailing.equalTo(filteringButton.snp.leading).offset(-8)
             $0.height.equalTo(50)
         }
         
+        searchBarLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(16)
+        }
+        
         searchImageView.snp.makeConstraints {
-            $0.centerY.equalTo(searchTextField.snp.centerY)
-            $0.trailing.equalTo(searchTextField.snp.trailing).offset(-6)
+            $0.centerY.equalTo(searchBarView.snp.centerY)
+            $0.trailing.equalTo(searchBarView.snp.trailing).offset(-6)
             $0.size.equalTo(40)
+        }
+        
+        searchBarButton.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
         
         filteringButton.snp.makeConstraints {

--- a/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
@@ -72,7 +72,9 @@ final class MapViewController: BaseViewController {
         rootView.searchBarButton
             .tapPublisher
             .sink {
-                let mapSearchViewController = MapSearchViewController()
+                let mapSearchViewController = MapSearchViewController(
+                    viewModel: MapSearchViewModel()
+                )
                 self.navigationController?.pushViewController(mapSearchViewController, animated: true)
             }
             .store(in: cancelBag)

--- a/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
@@ -168,8 +168,6 @@ private extension MapViewController {
 
 extension MapViewController: NMFMapViewTouchDelegate {
     func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
-//        view.endEditing(true)
-        
         if !rootView.mapDetailCardView.isHidden {
             erasePreviousSelectedMarker()
             

--- a/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
@@ -69,6 +69,14 @@ final class MapViewController: BaseViewController {
     }
     
     override func setAction() {
+        rootView.searchBarButton
+            .tapPublisher
+            .sink {
+                let mapSearchViewController = MapSearchViewController()
+                self.navigationController?.pushViewController(mapSearchViewController, animated: true)
+            }
+            .store(in: cancelBag)
+        
         rootView.filteringButton
             .tapPublisher
             .sink {
@@ -158,7 +166,7 @@ private extension MapViewController {
 
 extension MapViewController: NMFMapViewTouchDelegate {
     func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
-        view.endEditing(true)
+//        view.endEditing(true)
         
         if !rootView.mapDetailCardView.isHidden {
             erasePreviousSelectedMarker()

--- a/Roomie/Roomie/Presentation/MapSearch/Model/MapSearchModel.swift
+++ b/Roomie/Roomie/Presentation/MapSearch/Model/MapSearchModel.swift
@@ -1,0 +1,46 @@
+//
+//  MapSearchModel.swift
+//  Roomie
+//
+//  Created by 예삐 on 1/16/25.
+//
+
+import Foundation
+
+struct MapSearchModel {
+    let location: String
+    let address: String
+    let roadAddress: String
+}
+
+extension MapSearchModel {
+    static func mockMapSearchData() -> [MapSearchModel] {
+        return [
+            MapSearchModel(
+                location: "이화여자대학교",
+                address: "서울특별시 서대문구 대현동 11-1",
+                roadAddress: "서울특별시 서대문구 이화여대길 52"
+            ),
+            MapSearchModel(
+                location: "루미하우스",
+                address: "서울특별시 서대문구 대현동 11-1",
+                roadAddress: "서울특별시 서대문구 이화여대길 52"
+            ),
+            MapSearchModel(
+                location: "건국대학교",
+                address: "서울특별시 서대문구 대현동 11-1",
+                roadAddress: "서울특별시 서대문구 이화여대길 52"
+            ),
+            MapSearchModel(
+                location: "성신여자대학교",
+                address: "서울특별시 서대문구 대현동 11-1",
+                roadAddress: "서울특별시 서대문구 이화여대길 52"
+            ),
+            MapSearchModel(
+                location: "서울여자대학교",
+                address: "서울특별시 서대문구 대현동 11-1",
+                roadAddress: "서울특별시 서대문구 이화여대길 52"
+            )
+        ]
+    }
+}

--- a/Roomie/Roomie/Presentation/MapSearch/View/MapSearchCollectionViewCell.swift
+++ b/Roomie/Roomie/Presentation/MapSearch/View/MapSearchCollectionViewCell.swift
@@ -1,0 +1,140 @@
+//
+//  MapSearchCollectionViewCell.swift
+//  Roomie
+//
+//  Created by 예삐 on 1/16/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class MapSearchCollectionViewCell: BaseCollectionViewCell {
+        
+    // MARK: - UIComponent
+    
+    private let cellView = UIView()
+    
+    private let titleLabel = UILabel()
+    
+    private let roadAdressTitleView = UIView()
+    private let roadAdressTitleLabel = UILabel()
+    private let roadAdressLabel = UILabel()
+    
+    private let lotAdressTitleView = UIView()
+    private let lotAdressTitleLabel = UILabel()
+    private let lotAdressLabel = UILabel()
+    
+    // MARK: - UISetting
+
+    override func setStyle() {
+        cellView.do {
+            $0.backgroundColor = .grayscale1
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = UIColor.grayscale5.cgColor
+            $0.layer.cornerRadius = 8
+        }
+        
+        titleLabel.do {
+            $0.setText(style: .title2, color: .grayscale12)
+        }
+        
+        roadAdressTitleView.do {
+            $0.backgroundColor = .grayscale3
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = UIColor.grayscale5.cgColor
+            $0.layer.cornerRadius = 4
+        }
+        
+        roadAdressTitleLabel.do {
+            $0.setText("도로명", style: .caption2, color: .grayscale7)
+        }
+        
+        roadAdressLabel.do {
+            $0.setText(style: .body4, color: .grayscale9)
+        }
+        
+        lotAdressTitleView.do {
+            $0.backgroundColor = .grayscale3
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = UIColor.grayscale5.cgColor
+            $0.layer.cornerRadius = 4
+        }
+        
+        lotAdressTitleLabel.do {
+            $0.setText("지번", style: .caption2, color: .grayscale7)
+        }
+        
+        lotAdressLabel.do {
+            $0.setText(style: .body4, color: .grayscale9)
+        }
+    }
+    
+    override func setUI() {
+        addSubview(cellView)
+        cellView.addSubviews(
+            titleLabel,
+            roadAdressTitleView,
+            roadAdressTitleLabel,
+            roadAdressLabel,
+            lotAdressTitleView,
+            lotAdressTitleLabel,
+            lotAdressLabel
+        )
+    }
+    
+    override func setLayout() {
+        cellView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().inset(16)
+        }
+        
+        roadAdressTitleView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16)
+            $0.leading.equalToSuperview().inset(16)
+            $0.width.equalTo(38)
+            $0.height.equalTo(22)
+        }
+        
+        roadAdressTitleLabel.snp.makeConstraints {
+            $0.centerY.equalTo(roadAdressTitleView.snp.centerY)
+            $0.centerX.equalTo(roadAdressTitleView.snp.centerX)
+        }
+        
+        roadAdressLabel.snp.makeConstraints {
+            $0.centerY.equalTo(roadAdressTitleView.snp.centerY)
+            $0.leading.equalTo(roadAdressTitleView.snp.trailing).offset(8)
+        }
+        
+        lotAdressTitleView.snp.makeConstraints {
+            $0.top.equalTo(roadAdressTitleView.snp.bottom).offset(4)
+            $0.leading.equalToSuperview().inset(16)
+            $0.width.equalTo(38)
+            $0.height.equalTo(22)
+        }
+        
+        lotAdressTitleLabel.snp.makeConstraints {
+            $0.centerY.equalTo(lotAdressTitleView.snp.centerY)
+            $0.centerX.equalTo(lotAdressTitleView.snp.centerX)
+        }
+        
+        lotAdressLabel.snp.makeConstraints {
+            $0.centerY.equalTo(lotAdressTitleView.snp.centerY)
+            $0.leading.equalTo(lotAdressTitleView.snp.trailing).offset(8)
+        }
+    }
+}
+
+// MARK: - DataBind
+
+extension MapSearchCollectionViewCell {
+    func dataBind(_ data: MapSearchModel) {
+        titleLabel.updateText(data.location)
+        roadAdressLabel.updateText(data.roadAddress)
+        lotAdressLabel.updateText(data.address)
+    }
+}

--- a/Roomie/Roomie/Presentation/MapSearch/View/MapSearchCollectionViewCell.swift
+++ b/Roomie/Roomie/Presentation/MapSearch/View/MapSearchCollectionViewCell.swift
@@ -11,6 +11,14 @@ import SnapKit
 import Then
 
 final class MapSearchCollectionViewCell: BaseCollectionViewCell {
+    
+    // MARK: - Property
+    
+    override var isSelected: Bool {
+        didSet{
+            self.cellView.backgroundColor = isSelected ? .grayscale3 : .grayscale1
+        }
+    }
         
     // MARK: - UIComponent
     

--- a/Roomie/Roomie/Presentation/MapSearch/View/MapSearchView.swift
+++ b/Roomie/Roomie/Presentation/MapSearch/View/MapSearchView.swift
@@ -1,0 +1,73 @@
+//
+//  MapSearchView.swift
+//  Roomie
+//
+//  Created by 예삐 on 1/16/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class MapSearchView: BaseView {
+    
+    // MARK: - Property
+    
+    let backButton = UIButton()
+    
+    let searchTextField = MapTextField("원하는 장소를 찾아보세요")
+    
+    let searchImageView = UIImageView()
+    
+    let seperatorView = UIView()
+    
+    override func setStyle() {
+        backButton.do {
+            $0.setImage(.btnBack, for: .normal)
+        }
+        
+        searchTextField.do {
+            $0.addPadding(left: 16, right: 46)
+        }
+        
+        searchImageView.do {
+            $0.image = .icnSearch40
+        }
+        
+        seperatorView.do {
+            $0.backgroundColor = .grayscale4
+        }
+    }
+    
+    override func setUI() {
+        addSubviews(backButton, searchTextField, searchImageView, seperatorView)
+    }
+    
+    override func setLayout() {
+        backButton.snp.makeConstraints {
+            $0.centerY.equalTo(searchTextField.snp.centerY)
+            $0.leading.equalToSuperview().inset(4)
+            $0.size.equalTo(44)
+        }
+        
+        searchTextField.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide).inset(12)
+            $0.leading.equalTo(backButton.snp.trailing).offset(2)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(50)
+        }
+        
+        searchImageView.snp.makeConstraints {
+            $0.centerY.equalTo(searchTextField.snp.centerY)
+            $0.trailing.equalTo(searchTextField.snp.trailing).offset(-8)
+            $0.size.equalTo(40)
+        }
+        
+        seperatorView.snp.makeConstraints {
+            $0.top.equalTo(searchTextField.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+    }
+}

--- a/Roomie/Roomie/Presentation/MapSearch/View/MapSearchView.swift
+++ b/Roomie/Roomie/Presentation/MapSearch/View/MapSearchView.swift
@@ -17,10 +17,16 @@ final class MapSearchView: BaseView {
     let backButton = UIButton()
     
     let searchTextField = MapTextField("원하는 장소를 찾아보세요")
+    private let searchImageView = UIImageView()
+    private let seperatorView = UIView()
     
-    let searchImageView = UIImageView()
-    
-    let seperatorView = UIView()
+    let collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewFlowLayout().then {
+            $0.scrollDirection = .vertical
+            $0.minimumLineSpacing = 12
+        }
+    )
     
     override func setStyle() {
         backButton.do {
@@ -38,10 +44,16 @@ final class MapSearchView: BaseView {
         seperatorView.do {
             $0.backgroundColor = .grayscale4
         }
+        
+        collectionView.do {
+            $0.backgroundColor = .clear
+            $0.showsVerticalScrollIndicator = true
+            $0.showsHorizontalScrollIndicator = false
+        }
     }
     
     override func setUI() {
-        addSubviews(backButton, searchTextField, searchImageView, seperatorView)
+        addSubviews(backButton, searchTextField, searchImageView, seperatorView, collectionView)
     }
     
     override func setLayout() {
@@ -68,6 +80,12 @@ final class MapSearchView: BaseView {
             $0.top.equalTo(searchTextField.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(1)
+        }
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(seperatorView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview()
         }
     }
 }

--- a/Roomie/Roomie/Presentation/MapSearch/View/MapSearchView.swift
+++ b/Roomie/Roomie/Presentation/MapSearch/View/MapSearchView.swift
@@ -12,7 +12,7 @@ import Then
 
 final class MapSearchView: BaseView {
     
-    // MARK: - Property
+    // MARK: - UIComponent
     
     let backButton = UIButton()
     
@@ -27,6 +27,8 @@ final class MapSearchView: BaseView {
             $0.minimumLineSpacing = 12
         }
     )
+    
+    // MARK: - UISetting
     
     override func setStyle() {
         backButton.do {

--- a/Roomie/Roomie/Presentation/MapSearch/ViewController/MapSearchViewController.swift
+++ b/Roomie/Roomie/Presentation/MapSearch/ViewController/MapSearchViewController.swift
@@ -1,0 +1,47 @@
+//
+//  MapSearchViewController.swift
+//  Roomie
+//
+//  Created by 예삐 on 1/16/25.
+//
+
+import UIKit
+import Combine
+
+import CombineCocoa
+
+final class MapSearchViewController: BaseViewController {
+    
+    private let rootView = MapSearchView()
+    
+    private let cancelBag = CancelBag()
+    
+    override func loadView() {
+        view = rootView
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        navigationController?.setNavigationBarHidden(false, animated: false)
+    }
+    
+    override func setAction() {
+        hideKeyboardWhenDidTap()
+        
+        rootView.searchTextField.becomeFirstResponder()
+        
+        rootView.backButton
+            .tapPublisher
+            .sink { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .store(in: cancelBag)
+    }
+}

--- a/Roomie/Roomie/Presentation/MapSearch/ViewController/MapSearchViewController.swift
+++ b/Roomie/Roomie/Presentation/MapSearch/ViewController/MapSearchViewController.swift
@@ -12,12 +12,28 @@ import CombineCocoa
 
 final class MapSearchViewController: BaseViewController {
     
+    // MARK: - Property
+
     private let rootView = MapSearchView()
     
     private let cancelBag = CancelBag()
     
+    private let mapSearchData: [MapSearchModel] = MapSearchModel.mockMapSearchData()
+    
+    final let cellWidth: CGFloat = UIScreen.main.bounds.width - 40
+    final let cellHeight: CGFloat = 118
+    final let contentInset = UIEdgeInsets(top: 16, left: 20, bottom: 16, right: 20)
+    
+    // MARK: - LifeCycle
+    
     override func loadView() {
         view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setRegister()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -32,6 +48,13 @@ final class MapSearchViewController: BaseViewController {
         navigationController?.setNavigationBarHidden(false, animated: false)
     }
     
+    // MARK: - Functions
+    
+    override func setDelegate() {
+        rootView.collectionView.delegate = self
+        rootView.collectionView.dataSource = self
+    }
+    
     override func setAction() {
         hideKeyboardWhenDidTap()
         
@@ -43,5 +66,60 @@ final class MapSearchViewController: BaseViewController {
                 self?.navigationController?.popViewController(animated: true)
             }
             .store(in: cancelBag)
+    }
+    
+    private func setRegister() {
+        rootView.collectionView.register(
+            MapSearchCollectionViewCell.self,
+            forCellWithReuseIdentifier: MapSearchCollectionViewCell.reuseIdentifier
+        )
+    }
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension MapSearchViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        return CGSize(width: cellWidth, height: cellHeight)
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        insetForSectionAt section: Int
+    ) -> UIEdgeInsets {
+        return contentInset
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension MapSearchViewController: UICollectionViewDataSource {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
+        return mapSearchData.count
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: MapSearchCollectionViewCell.reuseIdentifier,
+            for: indexPath
+        ) as? MapSearchCollectionViewCell else {
+            return UICollectionViewCell()
+        }
+        
+        let data = mapSearchData[indexPath.row]
+        cell.dataBind(data)
+        
+        return cell
     }
 }

--- a/Roomie/Roomie/Presentation/MapSearch/ViewModel/MapSearchViewModel.swift
+++ b/Roomie/Roomie/Presentation/MapSearch/ViewModel/MapSearchViewModel.swift
@@ -6,7 +6,41 @@
 //
 
 import Foundation
+import Combine
 
 final class MapSearchViewModel {
+    private let mapSearchDataSubject = CurrentValueSubject<[MapSearchModel], Never>([])
+}
+
+extension MapSearchViewModel: ViewModelType {
+    struct Input {
+        let searchTextFieldEnterSubject: AnyPublisher<String, Never>
+    }
     
+    struct Output {
+        let mapSearchData: AnyPublisher<[MapSearchModel], Never>
+    }
+    
+    func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        input.searchTextFieldEnterSubject
+            .sink { [weak self] in
+                self?.fetchMapSearchData(key: $0)
+            }
+            .store(in: cancelBag)
+        
+        let mapSearchData = mapSearchDataSubject
+            .eraseToAnyPublisher()
+        
+        return Output(
+            mapSearchData: mapSearchData
+        )
+    }
+}
+
+private extension MapSearchViewModel {
+    
+    // TODO: 이후 API 통신으로 변경
+    func fetchMapSearchData(key: String) {
+        mapSearchDataSubject.send(MapSearchModel.mockMapSearchData())
+    }
 }

--- a/Roomie/Roomie/Presentation/MapSearch/ViewModel/MapSearchViewModel.swift
+++ b/Roomie/Roomie/Presentation/MapSearch/ViewModel/MapSearchViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  MapSearchViewModel.swift
+//  Roomie
+//
+//  Created by 예삐 on 1/16/25.
+//
+
+import Foundation
+
+final class MapSearchViewModel {
+    
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #41

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 지도 뷰에서 구현했던 텍스트필드를 디자인 명세에 따라 버튼으로 수정했어요.
- 지도 검색 텍스트필드를 구현했어요.
- 지도 검색 리스트 뷰를 구현했어요.
- 검색어가 입력되었을 때 목데이터를 fetch 해오는 방식(이후 API 통신으로 변경)으로 뷰모델을 구현했어요.

|    구현 내용    |   iPhone 13 mini   |   iPhone 15 pro   |
| :-------------: | :----------: | :----------: |
| 지도 검색 | <img src = "https://github.com/user-attachments/assets/970cb1c8-e898-4f44-8cd9-3a64e7e3da34" width ="250"> | <img src = "https://github.com/user-attachments/assets/6cd22548-5a50-4a3f-92fb-6ee56c1a6746" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
오늘 지도 뷰 바텀시트까지 하고 잘게 . . .ㅠㅠ!