### PR TITLE
[feat/#71] 디자인 명세 수정사항 반영

### DIFF
--- a/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
@@ -85,6 +85,7 @@ final class MapViewController: BaseViewController {
                 let mapFilterViewController = MapFilterViewController(
                     viewModel: MapFilterViewModel()
                 )
+                mapFilterViewController.hidesBottomBarWhenPushed = true
                 self.navigationController?.pushViewController(mapFilterViewController, animated: true)
             }
             .store(in: cancelBag)

--- a/Roomie/Roomie/Presentation/MapFilter/View/FilterPriceView.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/View/FilterPriceView.swift
@@ -22,7 +22,7 @@ final class FilterPriceView: BaseView {
     private let monthlyRentTitleLabel = UILabel()
     private let monthlyRentCenterView = UIView()
     let monthlyRentMinTextField = PriceTextField(placeHolder: "0")
-    let monthlyRentMaxTextField = PriceTextField(placeHolder: "500")
+    let monthlyRentMaxTextField = PriceTextField(placeHolder: "150")
     
     // MARK: - UISetting
     

--- a/Roomie/Roomie/Presentation/MapFilter/View/FilterPriceView.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/View/FilterPriceView.swift
@@ -18,17 +18,11 @@ final class FilterPriceView: BaseView {
     private let depositCenterView = UIView()
     let depositMinTextField = PriceTextField(placeHolder: "0")
     let depositMaxTextField = PriceTextField(placeHolder: "500")
-    let depositSlider = PriceSlider()
-    private let depositMinLabel = UILabel()
-    private let depositMaxLabel = UILabel()
     
     private let monthlyRentTitleLabel = UILabel()
     private let monthlyRentCenterView = UIView()
     let monthlyRentMinTextField = PriceTextField(placeHolder: "0")
     let monthlyRentMaxTextField = PriceTextField(placeHolder: "500")
-    let monthlyRentSlider = PriceSlider()
-    private let monthlyRentMinLabel = UILabel()
-    private let monthlyRentMaxLabel = UILabel()
     
     // MARK: - UISetting
     
@@ -41,42 +35,12 @@ final class FilterPriceView: BaseView {
             $0.backgroundColor = .grayscale5
         }
         
-        depositSlider.do {
-            $0.minValue = 0
-            $0.maxValue = 500
-            $0.min = 0
-            $0.max = 500
-        }
-        
-        depositMinLabel.do {
-            $0.setText("0만원", style: .body4, color: .grayscale12)
-        }
-        
-        depositMaxLabel.do {
-            $0.setText("500만원", style: .body4, color: .grayscale12)
-        }
-        
         monthlyRentTitleLabel.do {
             $0.setText("월세", style: .body2, color: .grayscale12)
         }
         
         monthlyRentCenterView.do {
             $0.backgroundColor = .grayscale5
-        }
-        
-        monthlyRentSlider.do {
-            $0.minValue = 0
-            $0.maxValue = 150
-            $0.min = 0
-            $0.max = 150
-        }
-        
-        monthlyRentMinLabel.do {
-            $0.setText("0만원", style: .body4, color: .grayscale12)
-        }
-        
-        monthlyRentMaxLabel.do {
-            $0.setText("150만원", style: .body4, color: .grayscale12)
         }
     }
     
@@ -86,16 +50,10 @@ final class FilterPriceView: BaseView {
             depositCenterView,
             depositMinTextField,
             depositMaxTextField,
-            depositSlider,
-            depositMinLabel,
-            depositMaxLabel,
             monthlyRentTitleLabel,
             monthlyRentCenterView,
             monthlyRentMinTextField,
-            monthlyRentMaxTextField,
-            monthlyRentSlider,
-            monthlyRentMinLabel,
-            monthlyRentMaxLabel
+            monthlyRentMaxTextField
         )
     }
     
@@ -126,24 +84,8 @@ final class FilterPriceView: BaseView {
             $0.height.equalTo(44)
         }
         
-        depositSlider.snp.makeConstraints {
-            $0.top.equalTo(depositMaxTextField.snp.bottom).offset(24)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(24)
-        }
-        
-        depositMinLabel.snp.makeConstraints {
-            $0.top.equalTo(depositSlider.snp.bottom).offset(4)
-            $0.leading.equalToSuperview().inset(20)
-        }
-        
-        depositMaxLabel.snp.makeConstraints {
-            $0.top.equalTo(depositSlider.snp.bottom).offset(4)
-            $0.trailing.equalToSuperview().inset(20)
-        }
-        
         monthlyRentTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(depositMinLabel.snp.bottom).offset(44)
+            $0.top.equalTo(depositMinTextField.snp.bottom).offset(44)
             $0.leading.equalToSuperview().inset(20)
         }
         
@@ -166,22 +108,6 @@ final class FilterPriceView: BaseView {
             $0.trailing.equalToSuperview().inset(20)
             $0.leading.equalTo(monthlyRentCenterView.snp.trailing).offset(4)
             $0.height.equalTo(44)
-        }
-        
-        monthlyRentSlider.snp.makeConstraints {
-            $0.top.equalTo(monthlyRentMaxTextField.snp.bottom).offset(24)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(24)
-        }
-        
-        monthlyRentMinLabel.snp.makeConstraints {
-            $0.top.equalTo(monthlyRentSlider.snp.bottom).offset(4)
-            $0.leading.equalToSuperview().inset(20)
-        }
-        
-        monthlyRentMaxLabel.snp.makeConstraints {
-            $0.top.equalTo(monthlyRentSlider.snp.bottom).offset(4)
-            $0.trailing.equalToSuperview().inset(20)
         }
     }
 }

--- a/Roomie/Roomie/Presentation/MapFilter/ViewController/MapFilterViewController.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/ViewController/MapFilterViewController.swift
@@ -22,8 +22,6 @@ final class MapFilterViewController: BaseViewController {
     
     private let depositMinTextSubject = PassthroughSubject<Int, Never>()
     private let depositMaxTextSubject = PassthroughSubject<Int, Never>()
-    private let depositMinRangeSubject = PassthroughSubject<Int, Never>()
-    private let depositMaxRangeSubject = PassthroughSubject<Int, Never>()
     
     private let monthlyRentMinTextSubject = PassthroughSubject<Int, Never>()
     private let monthlyRentMaxTextSubject = PassthroughSubject<Int, Never>()
@@ -111,15 +109,6 @@ final class MapFilterViewController: BaseViewController {
             }
             .store(in: cancelBag)
         
-        rootView.filterPriceView.depositSlider
-            .controlEventPublisher(for: .valueChanged)
-            .sink { [weak self] in
-                guard let self = self else { return }
-                self.depositMinRangeSubject.send(Int(rootView.filterPriceView.depositSlider.min))
-                self.depositMaxRangeSubject.send(Int(rootView.filterPriceView.depositSlider.max))
-            }
-            .store(in: cancelBag)
-        
         rootView.filterPriceView.monthlyRentMinTextField
             .textPublisher
             .compactMap { $0 }
@@ -137,15 +126,6 @@ final class MapFilterViewController: BaseViewController {
             .sink { [weak self] monthlyRentMaxText in
                 guard let self = self else { return }
                 self.monthlyRentMaxTextSubject.send(monthlyRentMaxText)
-            }
-            .store(in: cancelBag)
-        
-        rootView.filterPriceView.monthlyRentSlider
-            .controlEventPublisher(for: .valueChanged)
-            .sink { [weak self] in
-                guard let self = self else { return }
-                self.monthlyRentMinRangeSubject.send(Int(rootView.filterPriceView.monthlyRentSlider.min))
-                self.monthlyRentMaxRangeSubject.send(Int(rootView.filterPriceView.monthlyRentSlider.max))
             }
             .store(in: cancelBag)
         
@@ -276,12 +256,8 @@ private extension MapFilterViewController {
         let input = MapFilterViewModel.Input(
             depositMinText: depositMinTextSubject.eraseToAnyPublisher(),
             depositMaxText: depositMaxTextSubject.eraseToAnyPublisher(),
-            depositMinRange: depositMinRangeSubject.eraseToAnyPublisher(),
-            depositMaxRange: depositMaxRangeSubject.eraseToAnyPublisher(),
             monthlyRentMinText: monthlyRentMinTextSubject.eraseToAnyPublisher(),
             monthlyRentMaxText: monthlyRentMaxTextSubject.eraseToAnyPublisher(),
-            monthlyRentMinRange: monthlyRentMinRangeSubject.eraseToAnyPublisher(),
-            monthlyRentMaxRange: monthlyRentMaxRangeSubject.eraseToAnyPublisher(),
             maleButtonDidTap: maleButtonDidTapSubject.eraseToAnyPublisher(),
             femaleButtonDidTap: femaleButtonDidTapSubject.eraseToAnyPublisher(),
             genderDivisionButtonDidTap: genderDivisionButtonDidTapSubject.eraseToAnyPublisher(),
@@ -302,59 +278,11 @@ private extension MapFilterViewController {
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
         
-        output.depositMinRange
-            .map { Double($0) }
-            .sink { [weak self] depositMin in
-                guard let self = self else { return }
-                self.rootView.filterPriceView.depositSlider.min = depositMin
-            }
-            .store(in: cancelBag)
-        
-        output.depositMaxRange
-            .map { Double($0) }
-            .sink { [weak self] depositMax in
-                guard let self = self else { return }
-                self.rootView.filterPriceView.depositSlider.max = depositMax
-            }
-            .store(in: cancelBag)
-        
-        output.depositMinText
-            .map { String($0) }
-            .sink { [weak self] depositMin in
-                guard let self = self else { return }
-                self.rootView.filterPriceView.depositMinTextField.text = depositMin
-            }
-            .store(in: cancelBag)
-        
         output.depositMaxText
             .map { String($0) }
             .sink { [weak self] depositMax in
                 guard let self = self else { return }
                 self.rootView.filterPriceView.depositMaxTextField.text = depositMax
-            }
-            .store(in: cancelBag)
-        
-        output.monthlyRentMinRange
-            .map { Double($0) }
-            .sink { [weak self] monthlyRentMin in
-                guard let self = self else { return }
-                self.rootView.filterPriceView.monthlyRentSlider.min = monthlyRentMin
-            }
-            .store(in: cancelBag)
-        
-        output.monthlyRentMaxRange
-            .map { Double($0) }
-            .sink { [weak self] monthlyRentMax in
-                guard let self = self else { return }
-                self.rootView.filterPriceView.monthlyRentSlider.max = monthlyRentMax
-            }
-            .store(in: cancelBag)
-        
-        output.monthlyRentMinText
-            .map { String($0) }
-            .sink { [weak self] monthlyRentMin in
-                guard let self = self else { return }
-                self.rootView.filterPriceView.monthlyRentMinTextField.text = monthlyRentMin
             }
             .store(in: cancelBag)
         

--- a/Roomie/Roomie/Presentation/MapFilter/ViewController/MapFilterViewController.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/ViewController/MapFilterViewController.swift
@@ -90,8 +90,10 @@ final class MapFilterViewController: BaseViewController {
             .store(in: cancelBag)
         
         rootView.filterPriceView.depositMinTextField
-            .textPublisher
-            .compactMap { $0 }
+            .controlEventPublisher(for: .editingDidEnd)
+            .compactMap { [weak self] _ in
+                self?.rootView.filterPriceView.depositMinTextField.text
+            }
             .compactMap { Int($0) }
             .sink { [weak self] depositMinText in
                 guard let self = self else { return }
@@ -100,8 +102,10 @@ final class MapFilterViewController: BaseViewController {
             .store(in: cancelBag)
         
         rootView.filterPriceView.depositMaxTextField
-            .textPublisher
-            .compactMap { $0 }
+            .controlEventPublisher(for: .editingDidEnd)
+            .compactMap { [weak self] _ in
+                self?.rootView.filterPriceView.depositMaxTextField.text
+            }
             .compactMap { Int($0) }
             .sink { [weak self] depositMaxText in
                 guard let self = self else { return }
@@ -110,8 +114,10 @@ final class MapFilterViewController: BaseViewController {
             .store(in: cancelBag)
         
         rootView.filterPriceView.monthlyRentMinTextField
-            .textPublisher
-            .compactMap { $0 }
+            .controlEventPublisher(for: .editingDidEnd)
+            .compactMap { [weak self] _ in
+                self?.rootView.filterPriceView.monthlyRentMinTextField.text
+            }
             .compactMap { Int($0) }
             .sink { [weak self] monthlyRentMinText in
                 guard let self = self else { return }
@@ -120,8 +126,10 @@ final class MapFilterViewController: BaseViewController {
             .store(in: cancelBag)
         
         rootView.filterPriceView.monthlyRentMaxTextField
-            .textPublisher
-            .compactMap { $0 }
+            .controlEventPublisher(for: .editingDidEnd)
+            .compactMap { [weak self] _ in
+                self?.rootView.filterPriceView.monthlyRentMaxTextField.text
+            }
             .compactMap { Int($0) }
             .sink { [weak self] monthlyRentMaxText in
                 guard let self = self else { return }
@@ -278,11 +286,27 @@ private extension MapFilterViewController {
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
         
+        output.depositMinText
+            .map { String($0) }
+            .sink { [weak self] depositMin in
+                guard let self = self else { return }
+                self.rootView.filterPriceView.depositMinTextField.text = depositMin
+            }
+            .store(in: cancelBag)
+        
         output.depositMaxText
             .map { String($0) }
             .sink { [weak self] depositMax in
                 guard let self = self else { return }
                 self.rootView.filterPriceView.depositMaxTextField.text = depositMax
+            }
+            .store(in: cancelBag)
+        
+        output.monthlyRentMinText
+            .map { String($0) }
+            .sink { [weak self] monthlyRentMin in
+                guard let self = self else { return }
+                self.rootView.filterPriceView.monthlyRentMinTextField.text = monthlyRentMin
             }
             .store(in: cancelBag)
         

--- a/Roomie/Roomie/Presentation/MapFilter/ViewModel/MapFilterViewModel.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/ViewModel/MapFilterViewModel.swift
@@ -12,11 +12,11 @@ final class MapFilterViewModel {
     private let depositMaxValue: Int = 500
     private let monthlyRentMaxValue: Int = 150
     
-    private let depositMinSubject = CurrentValueSubject<Int, Never>(0)
-    private let depositMaxSubject = CurrentValueSubject<Int, Never>(500)
+    private let depositMinSubject = PassthroughSubject<Int, Never>()
+    private let depositMaxSubject = PassthroughSubject<Int, Never>()
     
-    private let monthlyRentMinSubject = CurrentValueSubject<Int, Never>(0)
-    private let monthlyRentMaxSubject = CurrentValueSubject<Int, Never>(150)
+    private let monthlyRentMinSubject = PassthroughSubject<Int, Never>()
+    private let monthlyRentMaxSubject = PassthroughSubject<Int, Never>()
     
     private let genderSubject = CurrentValueSubject<[String], Never>([])
     private let occupancyTypeSubject = CurrentValueSubject<[String], Never>([])
@@ -31,17 +31,9 @@ extension MapFilterViewModel: ViewModelType {
         let depositMinText: AnyPublisher<Int, Never>
         let depositMaxText: AnyPublisher<Int, Never>
         
-        /// 보증금 슬라이더 값
-        let depositMinRange: AnyPublisher<Int, Never>
-        let depositMaxRange: AnyPublisher<Int, Never>
-        
         /// 월세 텍스트필드 값
         let monthlyRentMinText: AnyPublisher<Int, Never>
         let monthlyRentMaxText: AnyPublisher<Int, Never>
-        
-        /// 월세 슬라이더 값
-        let monthlyRentMinRange: AnyPublisher<Int, Never>
-        let monthlyRentMaxRange: AnyPublisher<Int, Never>
         
         /// 성별 옵션
         let maleButtonDidTap: AnyPublisher<Void, Never>
@@ -73,17 +65,9 @@ extension MapFilterViewModel: ViewModelType {
         let depositMinText: AnyPublisher<Int, Never>
         let depositMaxText: AnyPublisher<Int, Never>
         
-        /// 보증금 슬라이더 값
-        let depositMinRange: AnyPublisher<Int, Never>
-        let depositMaxRange: AnyPublisher<Int, Never>
-        
         /// 월세 텍스트필드 값
         let monthlyRentMinText: AnyPublisher<Int, Never>
         let monthlyRentMaxText: AnyPublisher<Int, Never>
-        
-        /// 월세 슬라이더 값
-        let monthlyRentMinRange: AnyPublisher<Int, Never>
-        let monthlyRentMaxRange: AnyPublisher<Int, Never>
         
         /// 방 형태
         let isGenderEmpty: AnyPublisher<Bool, Never>
@@ -110,20 +94,6 @@ extension MapFilterViewModel: ViewModelType {
             }
             .store(in: cancelBag)
         
-        input.depositMinRange
-            .sink { [weak self] in
-                guard let self = self else { return }
-                self.depositMinSubject.send($0)
-            }
-            .store(in: cancelBag)
-        
-        input.depositMaxRange
-            .sink { [weak self] in
-                guard let self = self else { return }
-                self.depositMaxSubject.send($0)
-            }
-            .store(in: cancelBag)
-        
         input.monthlyRentMinText
             .sink { [weak self] in
                 guard let self = self else { return }
@@ -133,20 +103,6 @@ extension MapFilterViewModel: ViewModelType {
         
         input.monthlyRentMaxText
             .map { $0 > self.monthlyRentMaxValue ? self.monthlyRentMaxValue : $0 }
-            .sink { [weak self] in
-                guard let self = self else { return }
-                self.monthlyRentMaxSubject.send($0)
-            }
-            .store(in: cancelBag)
-        
-        input.monthlyRentMinRange
-            .sink { [weak self] in
-                guard let self = self else { return }
-                self.monthlyRentMinSubject.send($0)
-            }
-            .store(in: cancelBag)
-        
-        input.monthlyRentMaxRange
             .sink { [weak self] in
                 guard let self = self else { return }
                 self.monthlyRentMaxSubject.send($0)
@@ -373,12 +329,8 @@ extension MapFilterViewModel: ViewModelType {
         return Output(
             depositMinText: depositMin,
             depositMaxText: depositMax,
-            depositMinRange: depositMin,
-            depositMaxRange: depositMax,
             monthlyRentMinText: monthlyRentMin,
             monthlyRentMaxText: monthlyRentMax,
-            monthlyRentMinRange: monthlyRentMin,
-            monthlyRentMaxRange: monthlyRentMax,
             isGenderEmpty: isGenderEmpty,
             isOccupancyTypeEmpty: isOccupancyTypeEmpty,
             isPreferredDateEmpty: isPreferredEmpty,


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #71

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 디자인 명세 수정에 따라, 필터 뷰 가격 UI에서 슬라이더를 제외했어요.
- 최댓값 이상의 수를 입력했을 때는 자동으로 최댓값이 입력돼요.
- 최솟값보다 최댓값이 작거나 최댓값보다 최솟값이 클 경우 두 값이 바뀌어요.
- 필터 뷰의 하단 메뉴 바를 숨겼어요.

|    구현 내용    |   iPhone 13 mini   |   iPhone 15 pro   |
| :-------------: | :----------: | :----------: |
| 필터 뷰 | <img src = "https://github.com/user-attachments/assets/63fce001-f0a7-497b-b834-18fc48efe73d" width ="250"> | <img src = "https://github.com/user-attachments/assets/41e335dd-0e47-43dd-a7d7-336574ff47c8" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
얘들아 나 이제 졸려 ⋯