### PR TITLE
[feat/#66] home view 커스텀 네비바UI 구현

### DIFF
--- a/Roomie/Roomie/Global/Base/BaseViewController.swift
+++ b/Roomie/Roomie/Global/Base/BaseViewController.swift
@@ -39,6 +39,7 @@ extension BaseViewController {
     /// 네비게이션 바 커스텀
     func setNavigationBar(with string: String, isBorderHidden: Bool = false) {
         title = string
+        navigationItem.leftBarButtonItem = nil
         
         let barAppearance = UINavigationBarAppearance()
         barAppearance.backgroundColor = .grayscale1
@@ -53,7 +54,7 @@ extension BaseViewController {
         navigationController?.navigationBar.scrollEdgeAppearance = barAppearance
         
         let backButton = UIBarButtonItem(
-            image: .icnArrowLeftLine24,
+            image: .btnBack,
             style: .plain,
             target: self,
             action: #selector(backButtonDidTap)

--- a/Roomie/Roomie/Global/Extensions/CAGradientLayer+.swift
+++ b/Roomie/Roomie/Global/Extensions/CAGradientLayer+.swift
@@ -23,8 +23,8 @@ extension CAGradientLayer {
         
         switch style {
         case .home:
-            beginColor = UIColor(hexCode: "#FAFAFA")
-            endColor = UIColor(hexCode: "#626CF6")
+            beginColor = UIColor(hexCode: "#B2B6F4", alpha: 0)
+            endColor = UIColor(hexCode: "#B2B6F4")
         case .moodList:
             beginColor = UIColor(hexCode: "#EEEFFE")
             endColor = UIColor(hexCode: "#FFFFFF")

--- a/Roomie/Roomie/Presentation/Home/Model/HomeModel.swift
+++ b/Roomie/Roomie/Presentation/Home/Model/HomeModel.swift
@@ -29,32 +29,32 @@ struct UserInfo {
 extension RecentlyRoom {
     static func mockHomeData() -> [RecentlyRoom] {
         return [
-            RecentlyRoom(
-                houseID: 1,
-                monthlyRent: "30~50",
-                deposit: "200~300",
-                occupancyType: "1,2인실",
-                location: "서대문구 연희동",
-                genderPolicy: "여성전용",
-                locationDescription: "자이아파트",
-                isPinned: false,
-                moodTag: "#차분한",
-                contractTerm: 6,
-                mainImageURL: ""
-            ),
-            RecentlyRoom(
-                houseID: 2,
-                monthlyRent: "30~50",
-                deposit: "200~300",
-                occupancyType: "1,2,3인실",
-                location: "서대문구 대현동",
-                genderPolicy: "성별무관",
-                locationDescription: "자이아파트",
-                isPinned: true,
-                moodTag: "#활기찬",
-                contractTerm: 6,
-                mainImageURL: ""
-            )
+//            RecentlyRoom(
+//                houseID: 1,
+//                monthlyRent: "30~50",
+//                deposit: "200~300",
+//                occupancyType: "1,2인실",
+//                location: "서대문구 연희동",
+//                genderPolicy: "여성전용",
+//                locationDescription: "자이아파트",
+//                isPinned: false,
+//                moodTag: "#차분한",
+//                contractTerm: 6,
+//                mainImageURL: ""
+//            ),
+//            RecentlyRoom(
+//                houseID: 2,
+//                monthlyRent: "30~50",
+//                deposit: "200~300",
+//                occupancyType: "1,2,3인실",
+//                location: "서대문구 대현동",
+//                genderPolicy: "성별무관",
+//                locationDescription: "자이아파트",
+//                isPinned: true,
+//                moodTag: "#활기찬",
+//                contractTerm: 6,
+//                mainImageURL: ""
+//            )
         ]
     }
 }

--- a/Roomie/Roomie/Presentation/Home/View/HomeView.swift
+++ b/Roomie/Roomie/Presentation/Home/View/HomeView.swift
@@ -49,6 +49,8 @@ final class HomeView: BaseView {
     // MARK: - UISetting
     
     override func setStyle() {
+        self.backgroundColor = .primaryLight4
+        
         nameLabel.do {
             $0.setText(style: .heading2, color: .primaryPurple)
         }
@@ -139,7 +141,9 @@ final class HomeView: BaseView {
     
     override func setLayout() {
         gradientView.snp.makeConstraints{
-            $0.edges.equalToSuperview()
+            $0.top.equalToSuperview().inset(64)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(266)
         }
         
         scrollView.snp.makeConstraints{

--- a/Roomie/Roomie/Presentation/Home/View/HomeView.swift
+++ b/Roomie/Roomie/Presentation/Home/View/HomeView.swift
@@ -49,7 +49,9 @@ final class HomeView: BaseView {
     // MARK: - UISetting
     
     override func setStyle() {
-        self.backgroundColor = .primaryLight4
+        self.do {
+            $0.backgroundColor = .primaryLight4
+        }
         
         nameLabel.do {
             $0.setText(style: .heading2, color: .primaryPurple)

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -65,9 +65,9 @@ final class HomeViewController: BaseViewController {
         rootView.gradientView.setGradient(for: .home)
     }
     
-//    override func setView() {
-//        setNavigationBar(with: "")
-//    }
+    override func setView() {
+        setHomeNavigationBar()
+    }
     
     // MARK: - Functions
     
@@ -171,7 +171,43 @@ private extension HomeViewController {
     }
     
     func setHomeNavigationBar() {
+        title = nil
+        navigationItem.leftBarButtonItem = nil
         
+        let barAppearance = UINavigationBarAppearance()
+        let locationLabel = UILabel()
+        let likedButton = UIBarButtonItem(
+            image: .icnHeartLine24,
+            style: .plain,
+            target: self,
+            action: #selector(wishLishButtonDidTap)
+        )
+        let dropDownImageView = UIImageView(image: .icnArrowDownFilled16)
+        
+        let locationItem = UIBarButtonItem(customView: locationLabel)
+        let dropDownItem = UIBarButtonItem(customView: dropDownImageView)
+        likedButton.tintColor = .grayscale10
+        barAppearance.backgroundColor = .primaryLight4
+        barAppearance.shadowColor = nil
+        locationLabel.do {
+            $0.setText(userInfo.location, style: .title2, color: .grayscale10)
+        }
+        
+        navigationItem.rightBarButtonItem = likedButton
+        navigationItem.leftBarButtonItems = [locationItem, dropDownItem]
+        
+        
+        navigationController?.navigationBar.standardAppearance = barAppearance
+        navigationController?.navigationBar.scrollEdgeAppearance = barAppearance
+        
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+    }
+    
+    @objc
+    func wishLishButtonDidTap() {
+        let wishListViewController = WishListViewController(viewModel: WishListViewModel())
+        self.navigationController?.pushViewController(wishListViewController, animated: true)
     }
 }
 

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -65,6 +65,10 @@ final class HomeViewController: BaseViewController {
         rootView.gradientView.setGradient(for: .home)
     }
     
+//    override func setView() {
+//        setNavigationBar(with: "")
+//    }
+    
     // MARK: - Functions
     
     override func setAction() {
@@ -164,6 +168,10 @@ private extension HomeViewController {
                 $0.height.equalTo(226)
             }
         }
+    }
+    
+    func setHomeNavigationBar() {
+        
     }
 }
 

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -196,7 +196,6 @@ private extension HomeViewController {
         navigationItem.rightBarButtonItem = likedButton
         navigationItem.leftBarButtonItems = [locationItem, dropDownItem]
         
-        
         navigationController?.navigationBar.standardAppearance = barAppearance
         navigationController?.navigationBar.scrollEdgeAppearance = barAppearance
         

--- a/Roomie/Roomie/Presentation/WishList/Model/WishListModel.swift
+++ b/Roomie/Roomie/Presentation/WishList/Model/WishListModel.swift
@@ -24,32 +24,32 @@ struct WishListRoom {
 extension WishListRoom {
     static func mockHomeData() -> [WishListRoom] {
         return [
-//            WishListRoom(
-//                houseID: 1,
-//                monthlyRent: "30~50",
-//                deposit: "200~300",
-//                occupancyType: "1,2인실",
-//                location: "서대문구 연희동",
-//                genderPolicy: "여성전용",
-//                locationDescription: "자이아파트",
-//                isPinned: false,
-//                moodTag: "#차분한",
-//                contractTerm: 6,
-//                mainImageURL: ""
-//            ),
-//            WishListRoom(
-//                houseID: 2,
-//                monthlyRent: "30~50",
-//                deposit: "200~300",
-//                occupancyType: "1,2,3인실",
-//                location: "서대문구 대현동",
-//                genderPolicy: "성별무관",
-//                locationDescription: "자이아파트",
-//                isPinned: true,
-//                moodTag: "#활기찬",
-//                contractTerm: 6,
-//                mainImageURL: ""
-//            )
+            WishListRoom(
+                houseID: 1,
+                monthlyRent: "30~50",
+                deposit: "200~300",
+                occupancyType: "1,2인실",
+                location: "서대문구 연희동",
+                genderPolicy: "여성전용",
+                locationDescription: "자이아파트",
+                isPinned: false,
+                moodTag: "#차분한",
+                contractTerm: 6,
+                mainImageURL: ""
+            ),
+            WishListRoom(
+                houseID: 2,
+                monthlyRent: "30~50",
+                deposit: "200~300",
+                occupancyType: "1,2,3인실",
+                location: "서대문구 대현동",
+                genderPolicy: "성별무관",
+                locationDescription: "자이아파트",
+                isPinned: true,
+                moodTag: "#활기찬",
+                contractTerm: 6,
+                mainImageURL: ""
+            )
         ]
     }
 }

--- a/Roomie/Roomie/Presentation/WishList/Model/WishListModel.swift
+++ b/Roomie/Roomie/Presentation/WishList/Model/WishListModel.swift
@@ -24,32 +24,32 @@ struct WishListRoom {
 extension WishListRoom {
     static func mockHomeData() -> [WishListRoom] {
         return [
-            WishListRoom(
-                houseID: 1,
-                monthlyRent: "30~50",
-                deposit: "200~300",
-                occupancyType: "1,2인실",
-                location: "서대문구 연희동",
-                genderPolicy: "여성전용",
-                locationDescription: "자이아파트",
-                isPinned: false,
-                moodTag: "#차분한",
-                contractTerm: 6,
-                mainImageURL: ""
-            ),
-            WishListRoom(
-                houseID: 2,
-                monthlyRent: "30~50",
-                deposit: "200~300",
-                occupancyType: "1,2,3인실",
-                location: "서대문구 대현동",
-                genderPolicy: "성별무관",
-                locationDescription: "자이아파트",
-                isPinned: true,
-                moodTag: "#활기찬",
-                contractTerm: 6,
-                mainImageURL: ""
-            )
+//            WishListRoom(
+//                houseID: 1,
+//                monthlyRent: "30~50",
+//                deposit: "200~300",
+//                occupancyType: "1,2인실",
+//                location: "서대문구 연희동",
+//                genderPolicy: "여성전용",
+//                locationDescription: "자이아파트",
+//                isPinned: false,
+//                moodTag: "#차분한",
+//                contractTerm: 6,
+//                mainImageURL: ""
+//            ),
+//            WishListRoom(
+//                houseID: 2,
+//                monthlyRent: "30~50",
+//                deposit: "200~300",
+//                occupancyType: "1,2,3인실",
+//                location: "서대문구 대현동",
+//                genderPolicy: "성별무관",
+//                locationDescription: "자이아파트",
+//                isPinned: true,
+//                moodTag: "#활기찬",
+//                contractTerm: 6,
+//                mainImageURL: ""
+//            )
         ]
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #66 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- base네비바와 다른 홈 뷰용 커스텀 네비바를 구현했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 15 pro   |
| :-------------: | :----------: | :----------: |
| 홈 뷰 네비바 | <img src = "https://github.com/user-attachments/assets/30272c70-173c-4306-94a6-4e9f0b6be36b" width ="250"> | <img src = "https://github.com/user-attachments/assets/49441df2-6d8f-4c23-8361-ff490206843c" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 네비바 초기화

- HomeViewController와 BaseViewController에서 leftItem을 한 번 초기화해준 후 다시 할당하는 방식으로 구현했습니다.

<details>
<summary>HomeViewController</summary>

```swift
navigationItem.leftBarButtonItem = nil
```
</details>

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
# 루미아요가 최고야 우리 짱이야 너희 너무 잘하고 있어 우리 잘하구 있어 파이팅이야 난 너희가 자랑스러워 너희가 짱이야 🍀