### PR TITLE
[refactor/#84] 매물 상세 페이지 입주현황 TableView 구현

### DIFF
--- a/Roomie/Roomie/Presentation/HouseDetail/View/Cell/RoomStatusTableViewCell.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/Cell/RoomStatusTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  RoomStatusCollectionViewCell.swift
+//  RoomStatusTableViewCell.swift
 //  Roomie
 //
 //  Created by 김승원 on 1/18/25.
@@ -11,9 +11,11 @@ import SnapKit
 import Then
 
 // TODO: dataBind() 함수 구현 후 각 text 삭제
-final class RoomStatusCollectionViewCell: BaseCollectionViewCell {
+final class RoomStatusTableViewCell: BaseTableViewCell {
     
     // MARK: - UIComponent
+    
+    private let backView = UIView()
 
     private let statusView = RoomStatusView()
     
@@ -50,7 +52,7 @@ final class RoomStatusCollectionViewCell: BaseCollectionViewCell {
     // MARK: - UISetting
     
     override func setStyle() {
-        self.do {
+        backView.do {
             $0.layer.borderColor = UIColor.grayscale5.cgColor
             $0.layer.cornerRadius = 8
             $0.layer.borderWidth = 1
@@ -116,7 +118,9 @@ final class RoomStatusCollectionViewCell: BaseCollectionViewCell {
     }
     
     override func setUI() {
-        addSubviews(
+        addSubview(backView)
+        
+        backView.addSubviews(
             statusView,
             chevronRightIcon,
             nameLabel,
@@ -140,6 +144,12 @@ final class RoomStatusCollectionViewCell: BaseCollectionViewCell {
     }
     
     override func setLayout() {
+        backView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(12)
+        }
+        
         statusView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(16)
             $0.leading.equalToSuperview().inset(16)

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
@@ -51,8 +51,8 @@ final class HouseDetailView: BaseView {
     let groundRuleLabel3 = CheckIconLabel(text: "chill 코드는 굉장히 많지만, 신경도 안 쓰는 chill guy일 때")
     let groundRuleLabel4 = CheckIconLabel(text: "chill 코드는 굉장히 많지만, 신경도 안 쓰는 chill guy일 때")
     
-    
-    // 리팩을 쉽게 하기 위한 개행입니다.. 나중에 다 수정할게요!
+    // roomStatus Section
+    private let roomStatusTitleLabel = UILabel()
     
     
     private let bottomButtonbackView = UIView()
@@ -125,7 +125,7 @@ final class HouseDetailView: BaseView {
         }
         
         groundRuleTitleLabel.do {
-            $0.setText("그라운드 룰", style: .body2, color: .grayscale12)
+            $0.setText("숙소 규칙", style: .body2, color: .grayscale12)
         }
         
         groundRuleStackView.do {
@@ -135,8 +135,11 @@ final class HouseDetailView: BaseView {
             $0.distribution = .fill
         }
         
+        roomStatusTitleLabel.do {
+            $0.setText("입주현황", style: .heading5, color: .grayscale12)
+        }
         
-        // 리팩을 쉽게 하기 위한 개행입니다.. 나중에 다 수정할게요!
+        
         
         
         bottomButtonbackView.do {
@@ -168,7 +171,8 @@ final class HouseDetailView: BaseView {
             lookInsidePhotoButton,
             houseInfoSeparatorView,
             roomMoodTitleLabel,
-            roomMoodBackView
+            roomMoodBackView,
+            roomStatusTitleLabel
         )
         
         
@@ -294,7 +298,6 @@ final class HouseDetailView: BaseView {
         roomMoodBackView.snp.makeConstraints {
             $0.top.equalTo(roomMoodTitleLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(16) ///
         }
         
         roomMoodLabel.snp.makeConstraints {
@@ -339,6 +342,13 @@ final class HouseDetailView: BaseView {
             $0.bottom.equalToSuperview().inset(16)
             $0.bottom.equalToSuperview().inset(16)
         }
+        
+        roomStatusTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(roomMoodBackView.snp.bottom).offset(48)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(16) ///
+        }
+        
         
         
         // 리팩을 쉽게 하기 위한 개행입니다.. 나중에 다 수정할게요!

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
@@ -53,6 +53,8 @@ final class HouseDetailView: BaseView {
     
     // roomStatus Section
     private let roomStatusTitleLabel = UILabel()
+    let roomStatusTableView = UITableView()
+    
     
     
     private let bottomButtonbackView = UIView()
@@ -139,7 +141,13 @@ final class HouseDetailView: BaseView {
             $0.setText("입주현황", style: .heading5, color: .grayscale12)
         }
         
+        roomStatusTableView.do {
+            $0.separatorStyle = .none
+            $0.backgroundColor = .yellow
+        }
         
+        
+        // 리팩을 쉽게 하기 위한 개행입니다.. 나중에 다 수정할게요!
         
         
         bottomButtonbackView.do {
@@ -152,15 +160,8 @@ final class HouseDetailView: BaseView {
     }
     
     override func setUI() {
-        addSubviews(
-            scrollView,
-            bottomButtonbackView
-        )
-        
-        scrollView.addSubviews(
-            contentView
-        )
-        
+        addSubviews(scrollView, bottomButtonbackView)
+        scrollView.addSubviews(contentView)
         contentView.addSubviews(
             photoImageView,
             nameBackView,
@@ -172,7 +173,8 @@ final class HouseDetailView: BaseView {
             houseInfoSeparatorView,
             roomMoodTitleLabel,
             roomMoodBackView,
-            roomStatusTitleLabel
+            roomStatusTitleLabel,
+            roomStatusTableView
         )
         
         
@@ -183,15 +185,9 @@ final class HouseDetailView: BaseView {
         
         nameBackView.addSubview(nameLabel)
         
-        firstIconLabelStackView.addArrangedSubviews(
-            locationIconLabel,
-            occupancyTypesIconLabel
-        )
+        firstIconLabelStackView.addArrangedSubviews(locationIconLabel, occupancyTypesIconLabel)
         
-        secondIconLabelStackView.addArrangedSubviews(
-            occupancyStatusIconLabel,
-            genderPolicyIconLabel
-        )
+        secondIconLabelStackView.addArrangedSubviews(occupancyStatusIconLabel, genderPolicyIconLabel)
         
         roomMoodBackView.addSubviews(
             roomMoodLabel,
@@ -204,6 +200,7 @@ final class HouseDetailView: BaseView {
             groundRuleStackView
         )
         
+        // TODO: DataBind & 순서대로 addArrangedSubviews
         groundRuleStackView.addArrangedSubviews(
             groundRuleLabel1,
             groundRuleLabel2,
@@ -217,11 +214,7 @@ final class HouseDetailView: BaseView {
         
         
         
-        bottomButtonbackView
-            .addSubviews(
-                bottomButtonSeparatorView,
-                tourApplyButton
-            )
+        bottomButtonbackView.addSubviews(bottomButtonSeparatorView, tourApplyButton)
     }
     
     override func setLayout() {
@@ -346,6 +339,12 @@ final class HouseDetailView: BaseView {
         roomStatusTitleLabel.snp.makeConstraints {
             $0.top.equalTo(roomMoodBackView.snp.bottom).offset(48)
             $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        roomStatusTableView.snp.makeConstraints {
+            $0.top.equalTo(roomStatusTitleLabel.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(Screen.height(182 + 12))
             $0.bottom.equalToSuperview().inset(16) ///
         }
         
@@ -371,6 +370,22 @@ final class HouseDetailView: BaseView {
             $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).offset(-12)
             $0.trailing.equalToSuperview().inset(20)
             $0.width.equalTo(Screen.width(207))
+        }
+    }
+}
+
+// MARK: - Functions
+
+extension HouseDetailView {
+    /// roomStatusTableView의 높이를 동적으로 계산하는 함수입니다.
+    func updateRoomStatusTableViewHeight(
+        _ numberOfItems: Int,
+        height roomStatusCellHeight: CGFloat
+    ){
+        let tableViewHeight = CGFloat(numberOfItems) * roomStatusCellHeight
+    
+        roomStatusTableView.snp.updateConstraints {
+            $0.height.equalTo(tableViewHeight)
         }
     }
 }

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
@@ -113,5 +113,4 @@ extension HouseDetailViewController: UITableViewDelegate {
         
         return 0
     }
-    
 }

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
@@ -16,6 +16,9 @@ final class HouseDetailViewController: BaseViewController {
     
     private let rootView = HouseDetailView()
     
+    private let roomStatusCellHeight: CGFloat = 182 + 12
+    private let roomStatusCellCount = 2 // TODO: DataBind
+    
     private let viewWillAppearSubject = PassthroughSubject<Void, Never>()
     
     private let cancelBag = CancelBag()
@@ -30,6 +33,7 @@ final class HouseDetailViewController: BaseViewController {
         super.viewDidLoad()
        
         print("HouseDetailViewController: ViewDidLoad()")
+        setRegister()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -37,4 +41,77 @@ final class HouseDetailViewController: BaseViewController {
         
         viewWillAppearSubject.send(())
     }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        rootView.updateRoomStatusTableViewHeight(roomStatusCellCount, height: roomStatusCellHeight)
+        rootView.roomStatusTableView.layoutIfNeeded()
+        
+    }
+    
+    override func setDelegate() {
+        rootView.roomStatusTableView.dataSource = self
+        rootView.roomStatusTableView.delegate = self
+    }
+}
+
+// MARK: - Functions
+
+private extension HouseDetailViewController {
+    func setRegister() {
+        rootView.roomStatusTableView.register(
+            RoomStatusTableViewCell.self,
+            forCellReuseIdentifier: RoomStatusTableViewCell.reuseIdentifier
+        )
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension HouseDetailViewController: UITableViewDataSource {
+    func tableView(
+        _ tableView: UITableView,
+        numberOfRowsInSection section: Int
+    ) -> Int {
+        if tableView == rootView.roomStatusTableView {
+            return roomStatusCellCount // TODO: DataBind
+        }
+        
+        return 0
+    }
+    
+    func tableView(
+        _ tableView: UITableView,
+        cellForRowAt indexPath: IndexPath
+    ) -> UITableViewCell {
+        if tableView == rootView.roomStatusTableView {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: RoomStatusTableViewCell.reuseIdentifier,
+                for: indexPath
+            ) as? RoomStatusTableViewCell else {
+                return UITableViewCell()
+            }
+            cell.selectionStyle = .none
+            
+            // TODO: DataBinding
+            return cell
+        }
+        
+        return UITableViewCell()
+    }
+}
+
+extension HouseDetailViewController: UITableViewDelegate {
+    func tableView(
+        _ tableView: UITableView,
+        heightForRowAt indexPath: IndexPath
+    ) -> CGFloat {
+        if tableView == rootView.roomStatusTableView {
+            return roomStatusCellHeight
+        }
+        
+        return 0
+    }
+    
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #84 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 상세 매물 페이지의 입주 현황을 UITableView로 구현하였습니다.
- View에 TableView의 높이를 동적으로 계산하는 함수를 구현하였습니다. (땡스 투 천재 풀스택 개발자 현수👍🏻ㅋㅋㅋ)

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 입주현황 TableView | <img src = "https://github.com/user-attachments/assets/aceca20b-2f22-4d01-8ee2-12f2f8ea4666" width ="250"> | <img src = "https://github.com/user-attachments/assets/a8c02217-751f-462c-831d-8cce25dac91c" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### UITableView 동적 계산

- ViewController에서 SnapKit을 import하기 조큼 싫어서 저는 View에다가 로직을 구현하고 ViewController가 이를 부르도록 구현했어요

<details>
<summary>HouseDetailView.swift</summary>

```swift
extension HouseDetailViewController: UITableViewDelegate {
    func tableView(
        _ tableView: UITableView,
        heightForRowAt indexPath: IndexPath
    ) -> CGFloat {
        if tableView == rootView.roomStatusTableView {
            return roomStatusCellHeight
        }
        
        return 0
    }
}
```
</details>


## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

- 아 추가적으로 UITableViewCell은 기본적으로 Cell간의 간격을 제공하지 않기 때문에, Cell 내부에 자체적으로 아래에 12의 간격을 줘서 계산하여 TableView를 그리도록 구현했습니다.
- 그리고 수연이 알바 파이팅입니다! 👍🏻
