### PR TITLE
[feat/#102] 마이페이지 API 구현

### DIFF
--- a/Roomie/Roomie/Global/Base/BaseViewController.swift
+++ b/Roomie/Roomie/Global/Base/BaseViewController.swift
@@ -37,7 +37,11 @@ class BaseViewController: UIViewController {
 extension BaseViewController {
     
     /// 네비게이션 바 커스텀
-    func setNavigationBar(with string: String, isBorderHidden: Bool = false) {
+    func setNavigationBar(
+        with string: String,
+        isBorderHidden: Bool = false,
+        isBackButtonHidden: Bool = false
+    ) {
         title = string
         navigationItem.leftBarButtonItem = nil
         
@@ -62,7 +66,9 @@ extension BaseViewController {
             $0.tintColor = .grayscale10
         }
         
-        navigationItem.leftBarButtonItem = backButton
+        if !isBackButtonHidden {
+            navigationItem.leftBarButtonItem = backButton
+        }
         
         if !isBorderHidden {
             let identifier = "border"

--- a/Roomie/Roomie/Network/Service/UserService.swift
+++ b/Roomie/Roomie/Network/Service/UserService.swift
@@ -45,10 +45,23 @@ extension UserService: HomeServiceProtocol {
     }
 }
 
-final class MockUserService: HomeServiceProtocol {
+extension UserService: MyPageServiceProtocol {
+    func fetchMyPageData() async throws -> BaseResponseBody<MyPageResponseDTO>? {
+        return try await self.request(with: .fetchMyPageData)
+    }
+}
+
+final class MockHomeService: HomeServiceProtocol {
     func fetchHomeData() async throws -> BaseResponseBody<HomeResponseDTO>? {
         let mockData: HomeResponseDTO =
         HomeResponseDTO(name: "김루미", location: "논현동", recentlyViewedHouses: [])
+        return BaseResponseBody(code: 200, message: "", data: mockData)
+    }
+}
+
+final class MockMyPageService: MyPageServiceProtocol {
+    func fetchMyPageData() async throws -> BaseResponseBody<MyPageResponseDTO>? {
+        let mockData = MyPageResponseDTO(name: "김루미")
         return BaseResponseBody(code: 200, message: "", data: mockData)
     }
 }

--- a/Roomie/Roomie/Network/TargetType/UserTargetType.swift
+++ b/Roomie/Roomie/Network/TargetType/UserTargetType.swift
@@ -11,7 +11,7 @@ import Moya
 
 enum UserTargetType {
     case fetchUserHomeData
-    case fetchMypageData
+    case fetchMyPageData
 }
 
 extension UserTargetType: TargetType {
@@ -23,7 +23,7 @@ extension UserTargetType: TargetType {
         switch self {
         case .fetchUserHomeData:
             return "/v1/users/home"
-        case .fetchMypageData:
+        case .fetchMyPageData:
             return "/v1/users/mypage"
         }
     }

--- a/Roomie/Roomie/Presentation/Core/MainTabBarController.swift
+++ b/Roomie/Roomie/Presentation/Core/MainTabBarController.swift
@@ -28,7 +28,9 @@ final class MainTabBarController: UITabBarController {
         $0.tabBarItem.image = .icnMapLine24
     }
     
-    let myPageViewController: MyPageViewController = MyPageViewController().then {
+    let myPageViewController: MyPageViewController = MyPageViewController(
+        viewModel: MyPageViewModel(service: UserService())
+    ).then {
         $0.tabBarItem.title = "마이페이지"
         $0.tabBarItem.image = .icnUserLine24
     }

--- a/Roomie/Roomie/Presentation/MyPage/ServiceProtocol/MyPageServiceProtocol.swift
+++ b/Roomie/Roomie/Presentation/MyPage/ServiceProtocol/MyPageServiceProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  MyPageServiceProtocol.swift
+//  Roomie
+//
+//  Created by 예삐 on 1/22/25.
+//
+
+import Foundation
+
+protocol MyPageServiceProtocol {
+    func fetchMyPageData() async throws -> BaseResponseBody<MyPageResponseDTO>?
+}

--- a/Roomie/Roomie/Presentation/MyPage/View/Cell/MyPagePlusHeaderView.swift
+++ b/Roomie/Roomie/Presentation/MyPage/View/Cell/MyPagePlusHeaderView.swift
@@ -16,8 +16,9 @@ final class MyPagePlusHeaderView: BaseCollectionReusableView {
 
     private let profileImageView = UIImageView()
     
-    private let userInfoStackView = UIStackView()
     private let nicknameLabel = UILabel()
+    private let nicknameDefaultLabel = UILabel()
+    
     private let loginTypeView = UIView()
     private let loginTypeLabel = UILabel()
     
@@ -36,15 +37,12 @@ final class MyPagePlusHeaderView: BaseCollectionReusableView {
             $0.clipsToBounds = true
         }
         
-        userInfoStackView.do {
-            $0.axis = .vertical
-            $0.alignment = .top
-            $0.distribution = .fill
-            $0.spacing = 8
+        nicknameLabel.do {
+            $0.setText(style: .title2, color: .primaryPurple)
         }
         
-        nicknameLabel.do {
-            $0.setText(style: .title2, color: .grayscale12)
+        nicknameDefaultLabel.do {
+            $0.setText("님 안녕하세요!", style: .title2, color: .grayscale12)
         }
         
         loginTypeView.do {
@@ -76,12 +74,13 @@ final class MyPagePlusHeaderView: BaseCollectionReusableView {
     override func setUI() {
         addSubviews(
             profileImageView,
-            userInfoStackView,
+            nicknameLabel,
+            nicknameDefaultLabel,
+            loginTypeView,
             nextImageView,
             dividerView,
             titleLabel
         )
-        userInfoStackView.addArrangedSubviews(nicknameLabel, loginTypeView)
         loginTypeView.addSubview(loginTypeLabel)
     }
     
@@ -92,15 +91,25 @@ final class MyPagePlusHeaderView: BaseCollectionReusableView {
             $0.size.equalTo(60)
         }
         
-        userInfoStackView.snp.makeConstraints {
-            $0.centerY.equalTo(profileImageView.snp.centerY)
-            $0.leading.equalTo(profileImageView.snp.trailing).offset(12)
-        }
-        
         nextImageView.snp.makeConstraints {
             $0.centerY.equalTo(profileImageView.snp.centerY)
             $0.trailing.equalToSuperview().inset(10)
             $0.size.equalTo(44)
+        }
+        
+        nicknameLabel.snp.makeConstraints {
+            $0.bottom.equalTo(profileImageView.snp.centerY).offset(-4)
+            $0.leading.equalTo(profileImageView.snp.trailing).offset(12)
+        }
+        
+        nicknameDefaultLabel.snp.makeConstraints {
+            $0.centerY.equalTo(nicknameLabel.snp.centerY)
+            $0.leading.equalTo(nicknameLabel.snp.trailing).offset(2)
+        }
+        
+        loginTypeView.snp.makeConstraints {
+            $0.top.equalTo(profileImageView.snp.centerY).offset(4)
+            $0.leading.equalTo(profileImageView.snp.trailing).offset(12)
         }
         
         loginTypeLabel.snp.makeConstraints {
@@ -127,7 +136,6 @@ extension MyPagePlusHeaderView {
     }
     
     func dataBind(nickname: String) {
-        nicknameLabel.updateText("\(nickname) 님 안녕하세요!")
-        nicknameLabel.setHighlightText(nickname, style: .title2, color: .primaryPurple)
+        nicknameLabel.updateText(nickname)
     }
 }

--- a/Roomie/Roomie/Presentation/MyPage/View/Cell/MyPagePlusHeaderView.swift
+++ b/Roomie/Roomie/Presentation/MyPage/View/Cell/MyPagePlusHeaderView.swift
@@ -44,8 +44,7 @@ final class MyPagePlusHeaderView: BaseCollectionReusableView {
         }
         
         nicknameLabel.do {
-            $0.setText("이루미 님 안녕하세요!", style: .title2, color: .grayscale12)
-            $0.setHighlightText("이루미", style: .title2, color: .primaryPurple)
+            $0.setText(style: .title2, color: .grayscale12)
         }
         
         loginTypeView.do {
@@ -125,5 +124,10 @@ final class MyPagePlusHeaderView: BaseCollectionReusableView {
 extension MyPagePlusHeaderView {
     func configureHeader(title: String) {
         titleLabel.updateText(title)
+    }
+    
+    func dataBind(nickname: String) {
+        nicknameLabel.updateText("\(nickname) 님 안녕하세요!")
+        nicknameLabel.setHighlightText(nickname, style: .title2, color: .primaryPurple)
     }
 }

--- a/Roomie/Roomie/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/Roomie/Roomie/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -19,8 +19,6 @@ final class MyPageViewController: BaseViewController {
     private let cancelBag = CancelBag()
     
     // MARK: - Property
-
-    private var userName: String = ""
     
     private let plusData = MyPageModel.myPagePlusData()
     private let serviceData = MyPageModel.myPageServiceData()
@@ -60,7 +58,7 @@ final class MyPageViewController: BaseViewController {
     // MARK: - Functions
 
     override func setView() {
-        setNavigationBar(with: "마이페이지")
+        setNavigationBar(with: "마이페이지", isBackButtonHidden: true)
     }
     
     override func setDelegate() {
@@ -99,8 +97,13 @@ private extension MyPageViewController {
         output.userName
             .receive(on: RunLoop.main)
             .sink { [weak self] name in
-                self?.userName = name
-                self?.rootView.collectionView.reloadSections(IndexSet(integer: 0))
+                guard let self = self else { return }
+                if let header = self.rootView.collectionView.supplementaryView(
+                    forElementKind: UICollectionView.elementKindSectionHeader,
+                    at: IndexPath(item: 0, section: 0)
+                ) as? MyPagePlusHeaderView {
+                    header.dataBind(nickname: name)
+                }
             }
             .store(in: cancelBag)
     }
@@ -181,7 +184,6 @@ extension MyPageViewController: UICollectionViewDataSource {
                     withReuseIdentifier: MyPagePlusHeaderView.reuseIdentifier,
                     for: indexPath
                 ) as? MyPagePlusHeaderView else { return UICollectionReusableView() }
-                header.dataBind(nickname: userName)
                 header.configureHeader(title: "루미 더보기")
                 return header
             case 1:

--- a/Roomie/Roomie/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Roomie/Roomie/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -6,7 +6,51 @@
 //
 
 import Foundation
+import Combine
 
 final class MyPageViewModel {
+    private let service: MyPageServiceProtocol
+    private let userNameDataSubject = CurrentValueSubject<MyPageResponseDTO?, Never>(nil)
     
+    init(service: MyPageServiceProtocol) {
+        self.service = service
+    }
+}
+
+extension MyPageViewModel: ViewModelType {
+    struct Input {
+        let viewWillAppearSubject: AnyPublisher<Void, Never>
+    }
+    
+    struct Output {
+        let userName: AnyPublisher<String, Never>
+    }
+    
+    func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        input.viewWillAppearSubject
+            .sink { [weak self] in
+                self?.fetchMyPageData()
+            }
+            .store(in: cancelBag)
+        
+        let userNameData = userNameDataSubject
+            .compactMap { $0?.name }
+            .eraseToAnyPublisher()
+        
+        return Output(userName: userNameData)
+    }
+}
+
+private extension MyPageViewModel {
+    func fetchMyPageData() {
+        Task {
+            do {
+                guard let responseBody = try await service.fetchMyPageData(),
+                      let data = responseBody.data else { return }
+                userNameDataSubject.send(data)
+            } catch {
+                print(">>> \(error.localizedDescription) : \(#function)")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #102

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 마이페이지 TargetType 및 Service를 구현했어요.
- 마이페이지 API를 구현했어요.
- 백 버튼의 유무를 컨토를할 수 있도록 베이스 뷰 컨트롤러 로직을 수정했어요.

|    구현 내용    |   iPhone 13 mini   |   iPhone 15 pro   |
| :-------------: | :----------: | :----------: |
| 마이페이지 | <img src = "https://github.com/user-attachments/assets/0d43a83f-94db-42df-8b54-63e116fec806" width ="250"> | <img src = "https://github.com/user-attachments/assets/6f02b193-0b31-45bd-8567-509a6096d91f" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
방어 개맛도리임 ㅁㅊ음