### PR TITLE
[feat/#114] 지도 디테일 구현

### DIFF
--- a/Roomie/Roomie/Presentation/Map/View/MapView.swift
+++ b/Roomie/Roomie/Presentation/Map/View/MapView.swift
@@ -16,7 +16,7 @@ final class MapView: BaseView {
     // MARK: - UIComponent
     
     private let searchBarView = UIView()
-    private let searchBarLabel = UILabel()
+    let searchBarLabel = UILabel()
     private let searchImageView = UIImageView()
     let searchBarButton = UIButton()
     

--- a/Roomie/Roomie/Presentation/Map/View/MapView.swift
+++ b/Roomie/Roomie/Presentation/Map/View/MapView.swift
@@ -48,7 +48,8 @@ final class MapView: BaseView {
         }
         
         mapView.do {
-            $0.moveCamera(NMFCameraUpdate(scrollTo: NMGLatLng(lat: 37.555184166, lng: 126.936910322)))
+            $0.moveCamera(NMFCameraUpdate(scrollTo: NMGLatLng(lat: 37.55438, lng: 126.9377)))
+            $0.zoomLevel = 13
         }
         
         mapListButton.do {

--- a/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
@@ -139,6 +139,17 @@ private extension MapViewController {
                         marker.iconImage = NMFOverlayImage(name: "icn_map_pin_active")
                         self.selectedMarker = marker
                         
+                        let cameraUpdate = NMFCameraUpdate(
+                            scrollTo: NMGLatLng(lat: markerInfo.x, lng: markerInfo.y)
+                        )
+                        cameraUpdate.animation = .easeIn
+                        
+                        let zoomUpdate = NMFCameraUpdate(zoomTo: 14)
+                        zoomUpdate.animation = .easeIn
+                        
+                        rootView.mapView.moveCamera(cameraUpdate)
+                        rootView.mapView.moveCamera(zoomUpdate)
+                        
                         self.markerDidSelectSubject.send(markerInfo.houseID)
                         
                         return true
@@ -196,6 +207,17 @@ extension MapViewController: NMFMapViewTouchDelegate {
     func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
         if !rootView.mapDetailCardView.isHidden {
             erasePreviousSelectedMarker()
+            
+            let cameraUpdate = NMFCameraUpdate(
+                scrollTo: NMGLatLng(lat: 37.55438, lng: 126.9377)
+            )
+            cameraUpdate.animation = .easeIn
+            
+            let zoomUpdate = NMFCameraUpdate(zoomTo: 13)
+            zoomUpdate.animation = .easeIn
+            
+            rootView.mapView.moveCamera(cameraUpdate)
+            rootView.mapView.moveCamera(zoomUpdate)
             
             rootView.mapDetailCardView.isHidden = true
         }

--- a/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
@@ -80,6 +80,7 @@ final class MapViewController: BaseViewController {
                         builder: MapRequestDTO.Builder.shared
                     )
                 )
+                mapSearchViewController.delegate = self
                 self.navigationController?.pushViewController(mapSearchViewController, animated: true)
             }
             .store(in: cancelBag)
@@ -198,6 +199,19 @@ private extension MapViewController {
         if let previousMarker = self.selectedMarker {
             previousMarker.iconImage = NMFOverlayImage(name: "icn_map_pin_normal")
         }
+    }
+}
+
+// MARK: - MapSearchViewControllerDelegate
+
+extension MapViewController: MapSearchViewControllerDelegate {
+    func didSelectLocation(location: String, lat: Double, lng: Double) {
+        
+        rootView.searchBarLabel.setText(location, style: .title1, color: .grayscale12)
+        
+        let cameraUpdate = NMFCameraUpdate(scrollTo: NMGLatLng(lat: lat, lng: lng))
+        cameraUpdate.animation = .easeIn
+        rootView.mapView.moveCamera(cameraUpdate)
     }
 }
 

--- a/Roomie/Roomie/Presentation/MapSearch/ViewController/MapSearchViewController.swift
+++ b/Roomie/Roomie/Presentation/MapSearch/ViewController/MapSearchViewController.swift
@@ -10,6 +10,10 @@ import Combine
 
 import CombineCocoa
 
+protocol MapSearchViewControllerDelegate: AnyObject {
+    func didSelectLocation(location: String, lat: Double, lng: Double)
+}
+
 final class MapSearchViewController: BaseViewController {
     
     // MARK: - Property
@@ -21,6 +25,8 @@ final class MapSearchViewController: BaseViewController {
     private let cancelBag = CancelBag()
     
     private lazy var dataSource = createDiffableDataSource()
+    
+    weak var delegate: MapSearchViewControllerDelegate?
     
     final let cellWidth: CGFloat = UIScreen.main.bounds.width - 40
     final let cellHeight: CGFloat = 118
@@ -173,6 +179,14 @@ extension MapSearchViewController: UICollectionViewDelegateFlowLayout {
         let selectedLocation = dataSource.itemIdentifier(for: indexPath)
         if let location = selectedLocation {
             self.locationDidSelectSubject.send(location.address)
+        }
+        
+        if let selectedLocation = dataSource.itemIdentifier(for: indexPath) {
+            delegate?.didSelectLocation(
+                location: selectedLocation.location,
+                lat: selectedLocation.y,
+                lng: selectedLocation.x
+            )
         }
         
         self.navigationController?.popViewController(animated: true)

--- a/Roomie/Roomie/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/Roomie/Roomie/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -52,6 +52,7 @@ final class MyPageViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        updateSeletedCell()
         self.viewWillAppearSubject.send(())
     }
     
@@ -106,6 +107,15 @@ private extension MyPageViewController {
                 }
             }
             .store(in: cancelBag)
+    }
+    
+    func updateSeletedCell() {
+        for index in rootView.collectionView.indexPathsForVisibleItems {
+            if let cell = rootView.collectionView.cellForItem(at: index) as?
+                MyPageCollectionViewCell {
+                cell.isSelected = false
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #114

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 마커 클릭 시 줌 인/아웃 기능을 구현했어요.
- 지도 검색 시 해당 좌표로 카메라 이동 및 검색 장소를 레이블에 업데이트하는 로직을 구현했어요.

|    구현 내용    |   iPhone 13 mini   | 
| :-------------: | :----------: | 
| 지도 | <img src = "https://github.com/user-attachments/assets/553b6c6c-7eaa-4e84-b31e-71d4d9591627" width ="250"> | 

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
지금 레전드 비몽사몽임