### PR TITLE
[feat/#127] 매물 상세 -> 투어 플로우 네비게이션 연결

### DIFF
--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -88,7 +88,7 @@ final class HomeViewController: BaseViewController {
                 // TODO: 추후 재 화면연결 필요
                 let houseDetailViewController = HouseDetailViewController(
                     viewModel: HouseDetailViewModel(
-                        houseID: 2,
+                        houseID: 1,
                         service: HousesService()
                     )
                 )

--- a/Roomie/Roomie/Presentation/HouseDetail/Component/RoomTourButton.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/Component/RoomTourButton.swift
@@ -114,7 +114,7 @@ private extension RoomTourButton {
     func setRoomTourButton(title: String = "", subTitle: String = "") {
         roomButton.isEnabled = isTourAvailable
         backgroundColor = isTourAvailable ? .grayscale1 : .grayscale4
-        titleLabel.setText("룸\(title)", style: .title2, color: isTourAvailable ? .grayscale12 : .grayscale7)
+        titleLabel.setText(title, style: .title2, color: isTourAvailable ? .grayscale12 : .grayscale7)
         subTitleLabel.setText(subTitle, style: .body4, color: .grayscale7)
     }
     

--- a/Roomie/Roomie/Presentation/HouseDetail/Component/RoomTourButton.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/Component/RoomTourButton.swift
@@ -137,7 +137,8 @@ private extension RoomTourButton {
 }
 
 extension RoomTourButton {
-    func updateSubTitleLabel(with text: String) {
-        subTitleLabel.updateText(text)
+    func updateTitleLabel(title: String, subTitle: String) {
+        titleLabel.updateText(title)
+        subTitleLabel.updateText(subTitle)
     }
 }

--- a/Roomie/Roomie/Presentation/HouseDetail/Model/RoomButtonInfo.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/Model/RoomButtonInfo.swift
@@ -1,0 +1,15 @@
+//
+//  RoomButtonModel.swift
+//  Roomie
+//
+//  Created by 김승원 on 1/23/25.
+//
+
+import Foundation
+
+struct RoomButtonInfo {
+    let name: String
+    let status: Bool
+    let isTourAvailable: Bool
+    let subTitle: String
+}

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseAllPhotoView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseAllPhotoView.swift
@@ -82,7 +82,7 @@ final class HouseAllPhotoView: BaseView {
         }
         
         facilityDescriptionLabel.do {
-            $0.setText("설명설명", style: .body4, color: .grayscale12)
+            $0.setText(style: .body4, color: .grayscale12)
         }
         
         roomTitleLabel.do {

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailSheetView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailSheetView.swift
@@ -172,3 +172,12 @@ private extension HouseDetailSheetView {
         roomFTourButton.tag = 5
     }
 }
+
+extension HouseDetailSheetView {
+    func dataBind(_ roomButtonInfos: [RoomButtonInfo]) {
+        let visibleButtonCount = roomButtonInfos.count
+        for index in visibleButtonCount..<6 {
+            buttons[index].isHidden = true
+        }
+    }
+}

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailSheetView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailSheetView.swift
@@ -22,33 +22,10 @@ final class HouseDetailSheetView: BaseView {
     private let titleLabel = UILabel()
     private let separatorView = UIView()
     
-    let roomATourButton = RoomTourButton(name: "A", deposit: "500/50", isTourAvailable: true)
-    let roomBTourButton = RoomTourButton(name: "B", deposit: "500/50", isTourAvailable: true)
-    private let firstStackView = UIStackView()
-    
-    let roomCTourButton = RoomTourButton(name: "C", deposit: "500/50", isTourAvailable: true)
-    let roomDTourButton = RoomTourButton(name: "D", deposit: "500/50", isTourAvailable: false)
-    private let secondStackView = UIStackView()
-    
-    let roomETourButton = RoomTourButton(name: "E", deposit: "500/50", isTourAvailable: false)
-    let roomFTourButton = RoomTourButton(name: "F", deposit: "500/50", isTourAvailable: true)
-    private let thirdStackView = UIStackView()
+    private let evenStackView = UIStackView()
+    private let oddStackView = UIStackView()
     
     let tourApplyButton = RoomieButton(title: "투어신청하기", isEnabled: false)
-    
-    // MARK: - Initializer
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
-        setButtons()
-    }
-    
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        
-        setButtons()
-    }
     
     // MARK: - UISetting
     
@@ -68,25 +45,18 @@ final class HouseDetailSheetView: BaseView {
             $0.backgroundColor = .grayscale4
         }
         
-        firstStackView.do {
-            $0.axis = .horizontal
+        evenStackView.do {
+            $0.axis = .vertical
             $0.spacing = 11
             $0.alignment = .fill
-            $0.distribution = .fillEqually
+            $0.distribution = .equalSpacing
         }
         
-        secondStackView.do {
-            $0.axis = .horizontal
+        oddStackView.do {
+            $0.axis = .vertical
             $0.spacing = 11
             $0.alignment = .fill
-            $0.distribution = .fillEqually
-        }
-        
-        thirdStackView.do {
-            $0.axis = .horizontal
-            $0.spacing = 11
-            $0.alignment = .fill
-            $0.distribution = .fillEqually
+            $0.distribution = .equalSpacing
         }
     }
     
@@ -95,15 +65,10 @@ final class HouseDetailSheetView: BaseView {
             grabberView,
             titleLabel,
             separatorView,
-            firstStackView,
-            secondStackView,
-            thirdStackView,
+            evenStackView,
+            oddStackView,
             tourApplyButton
         )
-        
-        firstStackView.addArrangedSubviews(roomATourButton, roomBTourButton)
-        secondStackView.addArrangedSubviews(roomCTourButton, roomDTourButton)
-        thirdStackView.addArrangedSubviews(roomETourButton, roomFTourButton)
     }
     
     override func setLayout() {
@@ -125,22 +90,16 @@ final class HouseDetailSheetView: BaseView {
             $0.height.equalTo(1)
         }
         
-        firstStackView.snp.makeConstraints {
+        evenStackView.snp.makeConstraints {
             $0.top.equalTo(separatorView.snp.bottom).offset(20)
-            $0.horizontalEdges.equalToSuperview().inset(20)
-            $0.height.equalTo(Screen.height(60))
+            $0.leading.equalToSuperview().inset(20)
+            $0.width.equalTo(Screen.width(162))
         }
         
-        secondStackView.snp.makeConstraints {
-            $0.top.equalTo(firstStackView.snp.bottom).offset(11)
-            $0.horizontalEdges.equalToSuperview().inset(20)
-            $0.height.equalTo(Screen.height(60))
-        }
-        
-        thirdStackView.snp.makeConstraints {
-            $0.top.equalTo(secondStackView.snp.bottom).offset(11)
-            $0.horizontalEdges.equalToSuperview().inset(20)
-            $0.height.equalTo(Screen.height(60))
+        oddStackView.snp.makeConstraints {
+            $0.top.equalTo(separatorView.snp.bottom).offset(20)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.width.equalTo(Screen.width(162))
         }
         
         tourApplyButton.snp.makeConstraints {
@@ -151,33 +110,28 @@ final class HouseDetailSheetView: BaseView {
     }
 }
 
-private extension HouseDetailSheetView {
-    func setButtons() {
-        buttons.append(roomATourButton)
-        roomATourButton.tag = 0
-        
-        buttons.append(roomBTourButton)
-        roomBTourButton.tag = 1
-        
-        buttons.append(roomCTourButton)
-        roomCTourButton.tag = 2
-        
-        buttons.append(roomDTourButton)
-        roomDTourButton.tag = 3
-        
-        buttons.append(roomETourButton)
-        roomETourButton.tag = 4
-        
-        buttons.append(roomFTourButton)
-        roomFTourButton.tag = 5
-    }
-}
-
 extension HouseDetailSheetView {
-    func dataBind(_ roomButtonInfos: [RoomButtonInfo]) {
-        let visibleButtonCount = roomButtonInfos.count
-        for index in visibleButtonCount..<6 {
-            buttons[index].isHidden = true
+    func dataBind(_ data: [RoomButtonInfo]) {
+        for index in 0..<data.count {
+            let roomTourButton = RoomTourButton(
+                name: data[index].name,
+                deposit: data[index].subTitle,
+                isTourAvailable: data[index].isTourAvailable
+            )
+            
+            roomTourButton.tag = index
+            
+            buttons.append(roomTourButton)
+            
+            roomTourButton.snp.makeConstraints {
+                $0.height.equalTo(Screen.height(60))
+            }
+            
+            if index % 2 == 0 {
+                evenStackView.addArrangedSubview(roomTourButton)
+            } else {
+                oddStackView.addArrangedSubview(roomTourButton)
+            }
         }
     }
 }

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailSheetViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailSheetViewController.swift
@@ -8,15 +8,22 @@
 import UIKit
 import Combine
 
+protocol HouseDetailSheetViewControllerDelegate: AnyObject {
+    func tourApplyButtonDidTap(roomID: Int)
+}
+
 final class HouseDetailSheetViewController: BaseViewController {
     
     // MARK: - Property
+    
+    weak var delegate: HouseDetailSheetViewControllerDelegate?
     
     private let rootView = HouseDetailSheetView()
     
     private let viewModel: HouseDetailViewModel
     
     private let buttonIndexSubject = PassthroughSubject<Int, Never>()
+    private let tourApplyButtonTapSubject = PassthroughSubject<Void, Never>()
     
     private let viewWillAppearSubject = PassthroughSubject<Void, Never>()
     
@@ -51,6 +58,14 @@ final class HouseDetailSheetViewController: BaseViewController {
         
         viewWillAppearSubject.send(())
     }
+    
+    override func setAction() {
+        rootView.tourApplyButton.tapPublisher
+            .sink { [weak self] in
+                self?.tourApplyButtonTapSubject.send(())
+            }
+            .store(in: cancelBag)
+    }
 }
 
 // MARK: - Functions
@@ -60,7 +75,8 @@ private extension HouseDetailSheetViewController {
         let input = HouseDetailViewModel.Input(
             houseDetailViewWillAppear: Just(()).eraseToAnyPublisher(),
             bottomSheetViewWillAppear: viewWillAppearSubject.eraseToAnyPublisher(),
-            buttonIndexSubject: buttonIndexSubject.eraseToAnyPublisher()
+            buttonIndexSubject: buttonIndexSubject.eraseToAnyPublisher(),
+            tourApplyButtonTapSubject: tourApplyButtonTapSubject.eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(
@@ -87,8 +103,8 @@ private extension HouseDetailSheetViewController {
             .sink { [weak self] selectedRoomID in
                 guard let self else { return }
                 
-                // presentToTourCheckView
-                print(selectedRoomID)
+                delegate?.tourApplyButtonDidTap(roomID: selectedRoomID)
+                self.dismiss(animated: true)
             }
             .store(in: cancelBag)
     }

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailSheetViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailSheetViewController.swift
@@ -51,21 +51,6 @@ final class HouseDetailSheetViewController: BaseViewController {
         
         viewWillAppearSubject.send(())
     }
-    
-    override func setAction() {
-        for button in rootView.buttons {
-            button.roomButton.tapPublisher
-                .map { button.tag }
-                .sink { [weak self] index in
-                    guard let self else { return }
-                    
-                    // TODO: 선택된 index로 rooms[index].roomID ViewModel에 넘기기
-                    self.updateRadioButton(selectedIndex: index)
-                    self.buttonIndexSubject.send(index)
-                }
-                .store(in: cancelBag)
-        }
-    }
 }
 
 // MARK: - Functions
@@ -94,16 +79,32 @@ private extension HouseDetailSheetViewController {
             .sink { [weak self] roomButtonInfos in
                 guard let self else { return }
                 self.rootView.dataBind(roomButtonInfos)
+                setRadioButton()
             }
             .store(in: cancelBag)
         
         output.selectedRoomID
             .sink { [weak self] selectedRoomID in
                 guard let self else { return }
-                // TODO: 선택된 방의 RoomID를 주입시켜주면서 화면 연결
+                
+                // presentToTourCheckView
                 print(selectedRoomID)
             }
             .store(in: cancelBag)
+    }
+    
+    func setRadioButton() {
+        for button in rootView.buttons {
+            button.roomButton.tapPublisher
+                .map { button.tag }
+                .sink { [weak self] index in
+                    guard let self else { return }
+                    
+                    self.updateRadioButton(selectedIndex: index)
+                    self.buttonIndexSubject.send(index)
+                }
+                .store(in: cancelBag)
+        }
     }
     
     func updateRadioButton(selectedIndex: Int) {

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
@@ -127,7 +127,8 @@ private extension HouseDetailViewController {
         let input = HouseDetailViewModel.Input(
             houseDetailViewWillAppear: viewWillAppearSubject.eraseToAnyPublisher(),
             bottomSheetViewWillAppear: Just(()).eraseToAnyPublisher(),
-            buttonIndexSubject: PassthroughSubject<Int, Never>().eraseToAnyPublisher()
+            buttonIndexSubject: PassthroughSubject<Int, Never>().eraseToAnyPublisher(),
+            tourApplyButtonTapSubject: PassthroughSubject<Void, Never>().eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
@@ -415,7 +416,7 @@ extension HouseDetailViewController: UIScrollViewDelegate {
 extension HouseDetailViewController: UIAdaptivePresentationControllerDelegate {
     func presentHouseDetailSheet() {
         let houseDetailSheetViewController = HouseDetailSheetViewController(viewModel: viewModel)
-        
+        houseDetailSheetViewController.delegate = self
         let fullDetent = UISheetPresentationController.Detent.custom { _ in Screen.height(380) }
         
         if let sheet = houseDetailSheetViewController.sheetPresentationController {
@@ -427,5 +428,16 @@ extension HouseDetailViewController: UIAdaptivePresentationControllerDelegate {
         houseDetailSheetViewController.isModalInPresentation = false
         
         self.present(houseDetailSheetViewController, animated: true)
+    }
+}
+
+// MARK: - HouseDetailSheetViewControllerDelegate
+
+extension HouseDetailViewController: HouseDetailSheetViewControllerDelegate {
+    func tourApplyButtonDidTap(roomID: Int) {
+        print("HouseDetailViewController: \(roomID)")
+        
+        let tourCheckViewController = TourCheckViewController(viewModel: TourCheckViewModel())
+        navigationController?.pushViewController(tourCheckViewController, animated: true)
     }
 }

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
@@ -125,8 +125,9 @@ final class HouseDetailViewController: BaseViewController {
 private extension HouseDetailViewController {
     func bindViewModel() {
         let input = HouseDetailViewModel.Input(
-            viewWillApper: viewWillAppearSubject.eraseToAnyPublisher(),
-            roomIDSubject: PassthroughSubject<Int, Never>().eraseToAnyPublisher()
+            houseDetailViewWillAppear: viewWillAppearSubject.eraseToAnyPublisher(),
+            bottomSheetViewWillAppear: Just(()).eraseToAnyPublisher(),
+            buttonIndexSubject: PassthroughSubject<Int, Never>().eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
@@ -437,6 +437,8 @@ extension HouseDetailViewController: HouseDetailSheetViewControllerDelegate {
     func tourApplyButtonDidTap(roomID: Int) {
         print("HouseDetailViewController: \(roomID)")
         
+        setClearNavigationBar()
+        
         let tourCheckViewController = TourCheckViewController(viewModel: TourCheckViewModel())
         navigationController?.pushViewController(tourCheckViewController, animated: true)
     }

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
@@ -435,8 +435,7 @@ extension HouseDetailViewController: UIAdaptivePresentationControllerDelegate {
 
 extension HouseDetailViewController: HouseDetailSheetViewControllerDelegate {
     func tourApplyButtonDidTap(roomID: Int) {
-        print("HouseDetailViewController: \(roomID)")
-        
+    
         setClearNavigationBar()
         
         let tourCheckViewController = TourCheckViewController(viewModel: TourCheckViewModel())

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseSinglePhotoViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseSinglePhotoViewController.swift
@@ -60,7 +60,7 @@ final class HouseSinglePhotoViewController: BaseViewController {
     }
     
     override func setView() {
-        setNavigationBar(with: navigationBarTitle)
+        setNavigationBar(with: navigationBarTitle, isBorderHidden: true)
     }
 }
 

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewModel/HouseDetailViewModel.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewModel/HouseDetailViewModel.swift
@@ -184,7 +184,7 @@ extension HouseDetailViewModel: ViewModelType {
                         name: $0.name,
                         status: $0.status,
                         isTourAvailable: $0.isTourAvailable,
-                        subTitle: "\($0.deposit)/\($0.monthlyRent)"
+                        subTitle: "\($0.deposit / 10000)/\($0.monthlyRent / 10000)"
                     )
                 }
             }

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewModel/HouseDetailViewModel.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewModel/HouseDetailViewModel.swift
@@ -16,8 +16,9 @@ final class HouseDetailViewModel {
     
     private let houseDetailDataSubject = CurrentValueSubject<HouseDetailResponseDTO?, Never>(nil)
     
-    private let buttonIndexSubject = PassthroughSubject<Int, Never>()
+    private let radioButtonSubject = PassthroughSubject<Void, Never>()
     
+    private var buttonIndex: Int = 0
     private(set) var houseID: Int = 0
     
     @Published private(set) var roomInfos: [RoomInfo] = []
@@ -36,6 +37,7 @@ extension HouseDetailViewModel: ViewModelType {
         let houseDetailViewWillAppear: AnyPublisher<Void, Never>
         let bottomSheetViewWillAppear: AnyPublisher<Void, Never>
         let buttonIndexSubject: AnyPublisher<Int, Never>
+        let tourApplyButtonTapSubject: AnyPublisher<Void, Never>
     }
     
     struct Output {
@@ -61,7 +63,8 @@ extension HouseDetailViewModel: ViewModelType {
         input.buttonIndexSubject
             .sink { [weak self] roomID in
                 guard let self else { return }
-                self.buttonIndexSubject.send(roomID)
+                self.radioButtonSubject.send(())
+                self.buttonIndex = roomID
             }
             .store(in: cancelBag)
         
@@ -173,7 +176,7 @@ extension HouseDetailViewModel: ViewModelType {
             }
             .store(in: cancelBag)
         
-        let isTourApplyButtonEnabled = buttonIndexSubject
+        let isTourApplyButtonEnabled = radioButtonSubject
             .map { _ in true }
             .eraseToAnyPublisher()
         
@@ -190,9 +193,12 @@ extension HouseDetailViewModel: ViewModelType {
             }
             .eraseToAnyPublisher()
         
-        let selectedRoomID = buttonIndexSubject
-            .compactMap { self.houseDetailDataSubject.value?.rooms[$0].roomID }
+        let selectedRoomID = input.tourApplyButtonTapSubject
+        
+            .compactMap {
+                self.houseDetailDataSubject.value?.rooms[self.buttonIndex].roomID }
             .eraseToAnyPublisher()
+        
         
         return Output(
             navigationBarTitle: navigationBarTitle,

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewModel/HouseDetailViewModel.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewModel/HouseDetailViewModel.swift
@@ -16,7 +16,7 @@ final class HouseDetailViewModel {
     
     private let houseDetailDataSubject = CurrentValueSubject<HouseDetailResponseDTO?, Never>(nil)
     
-    private let roomIDSubject = PassthroughSubject<Int, Never>()
+    private let buttonIndexSubject = PassthroughSubject<Int, Never>()
     
     private(set) var houseID: Int = 0
     
@@ -33,8 +33,9 @@ final class HouseDetailViewModel {
 
 extension HouseDetailViewModel: ViewModelType {
     struct Input {
-        let viewWillApper: AnyPublisher<Void, Never>
-        let roomIDSubject: AnyPublisher<Int, Never>
+        let houseDetailViewWillAppear: AnyPublisher<Void, Never>
+        let bottomSheetViewWillAppear: AnyPublisher<Void, Never>
+        let buttonIndexSubject: AnyPublisher<Int, Never>
     }
     
     struct Output {
@@ -44,22 +45,23 @@ extension HouseDetailViewModel: ViewModelType {
         let safetyLivingFacilityInfo: AnyPublisher<[String], Never>
         let kitchenFacilityInfo: AnyPublisher<[String], Never>
         let isTourApplyButtonEnabled: AnyPublisher<Bool, Never>
+        let roomButtonInfos: AnyPublisher<[RoomButtonInfo], Never>
+        let selectedRoomID: AnyPublisher<Int, Never>
     }
     
     func transform(from input: Input, cancelBag: CancelBag) -> Output {
-        input.viewWillApper
+        input.houseDetailViewWillAppear
             .sink { [weak self] in
                 guard let self else { return }
-                
-                // TODO: houseID 받아오기
+            
                 self.fetchHouseDetailData(houseID: self.houseID)
             }
             .store(in: cancelBag)
         
-        input.roomIDSubject
+        input.buttonIndexSubject
             .sink { [weak self] roomID in
                 guard let self else { return }
-                self.roomIDSubject.send(roomID)
+                self.buttonIndexSubject.send(roomID)
             }
             .store(in: cancelBag)
         
@@ -171,8 +173,25 @@ extension HouseDetailViewModel: ViewModelType {
             }
             .store(in: cancelBag)
         
-        let isTourApplyButtonEnabled = self.roomIDSubject
+        let isTourApplyButtonEnabled = buttonIndexSubject
             .map { _ in true }
+            .eraseToAnyPublisher()
+        
+        let roomButtonInfos = input.bottomSheetViewWillAppear
+            .compactMap { _ in
+                self.houseDetailDataSubject.value?.rooms.map {
+                    RoomButtonInfo(
+                        name: $0.name,
+                        status: $0.status,
+                        isTourAvailable: $0.isTourAvailable,
+                        subTitle: "\($0.deposit)/\($0.monthlyRent)"
+                    )
+                }
+            }
+            .eraseToAnyPublisher()
+        
+        let selectedRoomID = buttonIndexSubject
+            .compactMap { self.houseDetailDataSubject.value?.rooms[$0].roomID }
             .eraseToAnyPublisher()
         
         return Output(
@@ -181,7 +200,9 @@ extension HouseDetailViewModel: ViewModelType {
             roomMoodInfo: roomMoodInfo,
             safetyLivingFacilityInfo: safetyLivingFacilityInfo,
             kitchenFacilityInfo: kitchenFacilityInfo,
-            isTourApplyButtonEnabled: isTourApplyButtonEnabled
+            isTourApplyButtonEnabled: isTourApplyButtonEnabled,
+            roomButtonInfos: roomButtonInfos,
+            selectedRoomID: selectedRoomID
         )
     }
 }

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewModel/HouseDetailViewModel.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewModel/HouseDetailViewModel.swift
@@ -199,7 +199,6 @@ extension HouseDetailViewModel: ViewModelType {
                 self.houseDetailDataSubject.value?.rooms[self.buttonIndex].roomID }
             .eraseToAnyPublisher()
         
-        
         return Output(
             navigationBarTitle: navigationBarTitle,
             houseMainInfo: houseMainInfo,


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #127 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 바텀시트에 버튼을 연동했어요
- 매물 상세 페이지에서 투어 플로우로 넘어가는 네비게이션을 연결했어요

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 바텀 시트, 네비게이션 구현 | <img src = "https://github.com/user-attachments/assets/f8e3a9e2-0c73-44c8-b104-9a93e1f5f9a0" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 바텀시트에서 버튼 누르면 네비게이션 형태로 화면 젼환...

- 바텀시트뷰가 modal 형태로 나오는 형식이기 때문에 바텀시트에서 navigationController가 끊겨서 화면 전환이 안되더라고요 ㅋㅋ
- 그래서 바텀시트뷰에서 Protocol을 만들고, 투어신청 버튼을 누르면 houseDetailViewController에 delegate가 이를 받을 수 있게 했어요

<details>
<summary>HouseDetailSheetViewController.swift</summary>

```swift
protocol HouseDetailSheetViewControllerDelegate: AnyObject {
    func tourApplyButtonDidTap(roomID: Int)
}
```
</details>
<br>

<details>
<summary>HouseDetailViewController.swift</summary>

```swift
// MARK: - HouseDetailSheetViewControllerDelegate

extension HouseDetailViewController: HouseDetailSheetViewControllerDelegate {
    func tourApplyButtonDidTap(roomID: Int) {
        print("HouseDetailViewController: \(roomID)")
        
        setClearNavigationBar()
        
        let tourCheckViewController = TourCheckViewController(viewModel: TourCheckViewModel())
        navigationController?.pushViewController(tourCheckViewController, animated: true)
    }
}
```
</details>

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

- 하