### PR TITLE
[feat/#134] 홈뷰, 찜리스트뷰 상세 매물 페이지 

### DIFF
--- a/Roomie/Roomie/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -15,6 +15,7 @@ final class HomeViewModel {
     
     private let homeDataSubject = PassthroughSubject<HomeResponseDTO, Never>()
     let pinnedInfoDataSubject = PassthroughSubject<(Int, Bool), Never>()
+    private let tappedHouseDataSubject = PassthroughSubject<Int, Never>()
     
     private(set) var houseListData: [HomeHouse] = []
     
@@ -27,6 +28,7 @@ extension HomeViewModel: ViewModelType {
     struct Input {
         let viewWillAppear: AnyPublisher<Void, Never>
         let pinnedHouseIDSubject: AnyPublisher<Int, Never>
+        let tappedHouseIDSubject: AnyPublisher<Int, Never>
     }
     
     struct Output {
@@ -34,6 +36,7 @@ extension HomeViewModel: ViewModelType {
         let houseList: AnyPublisher<[HomeHouse], Never>
         let houseCount: AnyPublisher<Int, Never>
         let pinnedInfo: AnyPublisher<(Int,Bool), Never>
+        let tappedInfo: AnyPublisher<Int, Never>
     }
     
     func transform(from input: Input, cancelBag: CancelBag) -> Output {
@@ -48,6 +51,13 @@ extension HomeViewModel: ViewModelType {
                 self?.updatePinnedHouse(houseID: houseID)
             }
             .store(in: cancelBag)
+        
+        input.tappedHouseIDSubject
+            .sink { [weak self] houseID in
+                self?.tappedHouseDataSubject.send(houseID)
+            }
+            .store(in: cancelBag)
+
         
         let houseListData = homeDataSubject
             .map { house in
@@ -89,7 +99,8 @@ extension HomeViewModel: ViewModelType {
             userInfo: userInfo,
             houseList: houseListData,
             houseCount: houseCount,
-            pinnedInfo: pinnedInfoData
+            pinnedInfo: pinnedInfoData,
+            tappedInfo: tappedHouseDataSubject.eraseToAnyPublisher()
         )
     }
 }

--- a/Roomie/Roomie/Presentation/WishList/ViewModel/WishListViewModel.swift
+++ b/Roomie/Roomie/Presentation/WishList/ViewModel/WishListViewModel.swift
@@ -16,6 +16,7 @@ final class WishListViewModel {
     
     private let wishListDataSubject = PassthroughSubject<WishListResponseDTO, Never>()
     let pinnedInfoDataSubject = PassthroughSubject<(Int, Bool), Never>()
+    private let tappedHouseDataSubject = PassthroughSubject<Int, Never>()
     
     private(set) var wishListData: [WishHouse] = []
     
@@ -28,11 +29,13 @@ extension WishListViewModel: ViewModelType {
     struct Input {
         let viewWillAppear: AnyPublisher<Void, Never>
         let pinnedHouseIDSubject: AnyPublisher<Int, Never>
+        let tappedHouseIDSubject: AnyPublisher<Int, Never>
     }
     
     struct Output {
         let wishList: AnyPublisher<[WishHouse], Never>
         let pinnedInfo: AnyPublisher<(Int,Bool), Never>
+        let tappedInfo: AnyPublisher<Int, Never>
     }
     
     func transform(from input: Input, cancelBag: CancelBag) -> Output {
@@ -45,6 +48,12 @@ extension WishListViewModel: ViewModelType {
         input.pinnedHouseIDSubject
             .sink { [weak self] houseID in
                 self?.updatePinnedHouse(houseID: houseID)
+            }
+            .store(in: cancelBag)
+        
+        input.tappedHouseIDSubject
+            .sink { [weak self] houseID in
+                self?.tappedHouseDataSubject.send(houseID)
             }
             .store(in: cancelBag)
         
@@ -76,7 +85,8 @@ extension WishListViewModel: ViewModelType {
         
         return Output(
             wishList: wishListData,
-            pinnedInfo: pinnedInfoData
+            pinnedInfo: pinnedInfoData,
+            tappedInfo: tappedHouseDataSubject.eraseToAnyPublisher()
         )
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #134 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 홈 뷰 상세매물페이지 화면 연결을 했습니다.
- 찜리스트 뷰 상세매물페이지 화면 연결을 했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 15 pro   |
| :-------------: | :----------: | :----------: |
| 화면 연결 | <img src = "https://github.com/user-attachments/assets/9c3f8ee1-c157-4374-9000-f7725f2af9a1" width ="250"> | <img src = "https://github.com/user-attachments/assets/10eb1796-283c-47d4-868c-72af5ea8ded6" width ="250"> |

## 👀 기타 더 이야기해볼 점
## 내 푸터 왜저래 아요들아 파이팅이다. 배고프다 야식먹고싶아.
