### PR TITLE
[feat/#129] 찜 API 구현 및 화면 전환

### DIFF
--- a/Roomie/Roomie/Network/Service/MapsService.swift
+++ b/Roomie/Roomie/Network/Service/MapsService.swift
@@ -45,7 +45,9 @@ extension MapsService: MapServiceProtocol {
         return try await self.request(with: .fetchMapData(request: request))
     }
     
-    // TODO: 찜 API 추가
+    func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>? {
+        return try await self.request(with: .updatePinnedHouse(houseID: houseID))
+    }
 }
 
 extension MapsService: MapSearchServiceProtocol {

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -202,7 +202,9 @@ private extension HomeViewController {
             .sink { [weak self] (houseID, isPinned) in
                 guard let self = self else { return }
 
-                if let index = self.viewModel.houseListData.firstIndex(where: { $0.houseID == houseID }) {
+                if let index = self.viewModel.homeDataSubject.value?.recentlyViewedHouses.firstIndex(
+                    where: { $0.houseID == houseID }
+                ) {
                     let indexPath = IndexPath(item: index, section: 0)
                     if let cell = self.rootView.houseListCollectionView.cellForItem(at: indexPath) as?
                         HouseListCollectionViewCell {
@@ -352,7 +354,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
         _ collectionView: UICollectionView,
         didSelectItemAt indexPath: IndexPath
     ) {
-        let houseID = viewModel.houseListData[indexPath.item].houseID
+        guard let houseID = viewModel.homeDataSubject.value?.recentlyViewedHouses[indexPath.item].houseID else { return }
         didTapHouseSubject.send(houseID)
     }
 }

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -31,7 +31,6 @@ final class HomeViewController: BaseViewController {
     
     private let viewWillAppearSubject = PassthroughSubject<Void, Never>()
     private let pinnedHouseIDSubject = PassthroughSubject<Int, Never>()
-    private let didTapHouseSubject = PassthroughSubject<Int, Never>()
         
     final let cellHeight: CGFloat = 112
     final let cellWidth: CGFloat = UIScreen.main.bounds.width - 32
@@ -129,7 +128,6 @@ final class HomeViewController: BaseViewController {
             .tapPublisher
             .sink {
                 let neatMoodListViewController = MoodListViewController(
-                    
                     moodType: .neat
                 )
                 neatMoodListViewController.hidesBottomBarWhenPushed = true
@@ -164,8 +162,7 @@ private extension HomeViewController {
     func bindViewModel() {
         let input = HomeViewModel.Input(
             viewWillAppear: viewWillAppearSubject.eraseToAnyPublisher(),
-            pinnedHouseIDSubject: pinnedHouseIDSubject.eraseToAnyPublisher(),
-            tappedHouseIDSubject: didTapHouseSubject.eraseToAnyPublisher()
+            pinnedHouseIDSubject: pinnedHouseIDSubject.eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
@@ -214,20 +211,6 @@ private extension HomeViewController {
                 if isPinned == false {
                     Toast().show(message: "찜 목록에서 삭제되었어요", inset: 8, view: rootView)
                 }
-            }
-            .store(in: cancelBag)
-        
-        output.tappedInfo
-            .receive(on: RunLoop.main)
-            .sink { [weak self] houseID in
-                guard let self = self else { return }
-                self.houseID = houseID
-                
-                let houseDetailViewController = HouseDetailViewController(
-                    viewModel: HouseDetailViewModel(houseID: houseID, service: HousesService())
-                )
-                houseDetailViewController.hidesBottomBarWhenPushed = true
-                self.navigationController?.pushViewController(houseDetailViewController, animated: true)
             }
             .store(in: cancelBag)
     }
@@ -355,7 +338,11 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
         didSelectItemAt indexPath: IndexPath
     ) {
         guard let houseID = viewModel.homeDataSubject.value?.recentlyViewedHouses[indexPath.item].houseID else { return }
-        didTapHouseSubject.send(houseID)
+        let houseDetailViewController = HouseDetailViewController(
+            viewModel: HouseDetailViewModel(houseID: houseID, service: HousesService())
+        )
+        houseDetailViewController.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(houseDetailViewController, animated: true)
     }
 }
 

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -36,8 +36,6 @@ final class HomeViewController: BaseViewController {
     final let cellWidth: CGFloat = UIScreen.main.bounds.width - 32
     final let contentInterSpacing: CGFloat = 4
     
-    var houseID: Int = 0
-    
     private var homeNavigationBarStatus: homeNavigationBarStatus = .scrolled {
         didSet {
             setHomeNavigationBarStatus()
@@ -87,18 +85,8 @@ final class HomeViewController: BaseViewController {
     override func setAction() {
         rootView.updateButton.updateButton
             .tapPublisher
-            .sink { [weak self] in
-                let houseDetailViewController = HouseDetailViewController(
-                    viewModel: HouseDetailViewModel(
-                        houseID: {
-                            guard let self = self else { return 0 }
-                            return self.houseID
-                        }(),
-                        service: HousesService()
-                    )
-                )
-                houseDetailViewController.hidesBottomBarWhenPushed = true
-                self?.navigationController?.pushViewController(houseDetailViewController, animated: true)
+            .sink {
+                // TODO: 웹 뷰 화면 전환
             }
             .store(in: cancelBag)
         

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -341,7 +341,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
 extension HomeViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y
-        if offsetY > -94 {
+        if offsetY > -90 {
             homeNavigationBarStatus = .top
         } else {
             homeNavigationBarStatus = .scrolled
@@ -349,7 +349,8 @@ extension HomeViewController: UIScrollViewDelegate {
         
         let maxOffsetY = rootView.scrollView.contentSize.height - rootView.scrollView.bounds.height
 
-        rootView.backgroundColor = rootView.scrollView.contentOffset.y >= maxOffsetY ? .grayscale1 : .primaryLight4
+        rootView.backgroundColor = rootView.scrollView.contentOffset.y >=
+        maxOffsetY ? .grayscale1 : .primaryLight4
     }
 }
 

--- a/Roomie/Roomie/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -48,7 +48,6 @@ extension HomeViewModel: ViewModelType {
                 self?.updatePinnedHouse(houseID: houseID)
             }
             .store(in: cancelBag)
-
         
         let houseListData = homeDataSubject
             .compactMap { $0 }

--- a/Roomie/Roomie/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -11,6 +11,7 @@ import Combine
 final class HomeViewModel {
     
     // MARK: - Property
+    
     private let service: HomeServiceProtocol
     
     let homeDataSubject = CurrentValueSubject<HomeResponseDTO?, Never>(nil)
@@ -26,7 +27,6 @@ extension HomeViewModel: ViewModelType {
     struct Input {
         let viewWillAppear: AnyPublisher<Void, Never>
         let pinnedHouseIDSubject: AnyPublisher<Int, Never>
-        let tappedHouseIDSubject: AnyPublisher<Int, Never>
     }
     
     struct Output {
@@ -34,7 +34,6 @@ extension HomeViewModel: ViewModelType {
         let houseList: AnyPublisher<[HomeHouse], Never>
         let houseCount: AnyPublisher<Int, Never>
         let pinnedInfo: AnyPublisher<(Int,Bool), Never>
-        let tappedInfo: AnyPublisher<Int, Never>
     }
     
     func transform(from input: Input, cancelBag: CancelBag) -> Output {
@@ -47,12 +46,6 @@ extension HomeViewModel: ViewModelType {
         input.pinnedHouseIDSubject
             .sink { [weak self] houseID in
                 self?.updatePinnedHouse(houseID: houseID)
-            }
-            .store(in: cancelBag)
-        
-        input.tappedHouseIDSubject
-            .sink { [weak self] houseID in
-                self?.didTapHouseDataSubject.send(houseID)
             }
             .store(in: cancelBag)
 
@@ -97,8 +90,7 @@ extension HomeViewModel: ViewModelType {
             userInfo: userInfo,
             houseList: houseListData,
             houseCount: houseCount,
-            pinnedInfo: pinnedInfoData,
-            tappedInfo: didTapHouseDataSubject.eraseToAnyPublisher()
+            pinnedInfo: pinnedInfoData
         )
     }
 }

--- a/Roomie/Roomie/Presentation/Map/ServiceProtocol/MapServiceProtocol.swift
+++ b/Roomie/Roomie/Presentation/Map/ServiceProtocol/MapServiceProtocol.swift
@@ -10,5 +10,5 @@ import Foundation
 protocol MapServiceProtocol {
     func fetchMapData(request: MapRequestDTO) async throws -> BaseResponseBody<MapResponseDTO>?
     
-    // TODO: 찜 API 추가
+    func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>?
 }

--- a/Roomie/Roomie/Presentation/Map/ViewController/MapListSheetViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapListSheetViewController.swift
@@ -8,6 +8,10 @@
 import UIKit
 import Combine
 
+protocol MapListSheetViewControllerDelegate: AnyObject {
+    func houseCellDidTap(houseID: Int)
+}
+
 final class MapListSheetViewController: BaseViewController {
     
     // MARK: - Property
@@ -21,6 +25,8 @@ final class MapListSheetViewController: BaseViewController {
     final let cellWidth: CGFloat = UIScreen.main.bounds.width - 32
     final let cellHeight: CGFloat = 112
     final let contentInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    
+    weak var delegate: MapListSheetViewControllerDelegate?
     
     private let pinnedHouseIDSubject = PassthroughSubject<Int, Never>()
     
@@ -157,5 +163,14 @@ extension MapListSheetViewController: UICollectionViewDelegateFlowLayout {
         insetForSectionAt section: Int
     ) -> UIEdgeInsets {
         return contentInset
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        didSelectItemAt indexPath: IndexPath
+    ) {
+        guard let houseID = viewModel.mapDataSubject.value?.houses[indexPath.item].houseID else { return }
+        delegate?.houseCellDidTap(houseID: houseID)
+        self.dismiss(animated: true)
     }
 }

--- a/Roomie/Roomie/Presentation/Map/ViewController/MapListSheetViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapListSheetViewController.swift
@@ -22,6 +22,8 @@ final class MapListSheetViewController: BaseViewController {
     final let cellHeight: CGFloat = 112
     final let contentInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
     
+    private let pinnedHouseIDSubject = PassthroughSubject<Int, Never>()
+    
     private lazy var dataSource = createDiffableDataSource()
     
     // MARK: - Initializer
@@ -67,7 +69,8 @@ private extension MapListSheetViewController {
         let input = MapViewModel.Input(
             viewWillAppear: Just(()).eraseToAnyPublisher(),
             markerDidSelect: PassthroughSubject<Int, Never>().eraseToAnyPublisher(),
-            eraseButtonDidTap: PassthroughSubject<Void, Never>().eraseToAnyPublisher()
+            eraseButtonDidTap: PassthroughSubject<Void, Never>().eraseToAnyPublisher(),
+            pinnedHouseID: pinnedHouseIDSubject.eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
@@ -84,6 +87,26 @@ private extension MapListSheetViewController {
                 }
             }
             .store(in: cancelBag)
+        
+        output.pinnedInfo
+            .receive(on: RunLoop.main)
+            .sink { [weak self] (houseID, isPinned) in
+                guard let self = self else { return }
+                
+                if let index = self.viewModel.mapDataSubject.value?.houses.firstIndex(
+                    where: { $0.houseID == houseID }
+                ) {
+                    let indexPath = IndexPath(item: index, section: 0)
+                    if let cell = self.rootView.collectionView.cellForItem(at: indexPath) as?
+                        HouseListCollectionViewCell {
+                        cell.updateWishButton(isPinned: isPinned)
+                    }
+                }
+                if isPinned == false {
+                    Toast().show(message: "찜 목록에서 삭제되었어요", inset: 32, view: rootView)
+                }
+            }
+            .store(in: cancelBag)
     }
     
     func createDiffableDataSource() -> UICollectionViewDiffableDataSource<Int, House> {
@@ -96,6 +119,13 @@ private extension MapListSheetViewController {
             ) as? HouseListCollectionViewCell else {
                 return UICollectionViewCell()
             }
+            
+            cell.wishButton
+                .controlEventPublisher(for: .touchUpInside)
+                .sink {
+                    self.pinnedHouseIDSubject.send(model.houseID)
+                }
+                .store(in: self.cancelBag)
             
             cell.dataBind(model)
             return cell

--- a/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
@@ -127,7 +127,8 @@ private extension MapViewController {
         let input = MapViewModel.Input(
             viewWillAppear: viewWillAppearSubject.eraseToAnyPublisher(),
             markerDidSelect: markerDidSelectSubject.eraseToAnyPublisher(),
-            eraseButtonDidTap: eraseButtonDidTapSubject.eraseToAnyPublisher()
+            eraseButtonDidTap: eraseButtonDidTapSubject.eraseToAnyPublisher(),
+            pinnedHouseID: PassthroughSubject<Int, Never>().eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)

--- a/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
@@ -266,6 +266,8 @@ extension MapViewController: UIAdaptivePresentationControllerDelegate {
             viewModel: MapViewModel(service: MapsService(), builder: MapRequestDTO.Builder.shared)
         )
         
+        mapListSheetViewController.delegate = self
+        
         let mediumDetent = UISheetPresentationController.Detent.custom { _ in 348 }
         let largeDetent = UISheetPresentationController.Detent.custom { _ in 648 }
         
@@ -277,5 +279,15 @@ extension MapViewController: UIAdaptivePresentationControllerDelegate {
         mapListSheetViewController.isModalInPresentation = false
         
         self.present(mapListSheetViewController, animated: true)
+    }
+}
+
+extension MapViewController: MapListSheetViewControllerDelegate {
+    func houseCellDidTap(houseID: Int) {
+        let houseDetailViewController = HouseDetailViewController(
+            viewModel: HouseDetailViewModel(houseID: houseID, service: HousesService())
+        )
+        houseDetailViewController.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(houseDetailViewController, animated: true)
     }
 }

--- a/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
@@ -108,8 +108,8 @@ final class MapViewController: BaseViewController {
             .sink { [weak self] in
                 self?.eraseButtonDidTapSubject.send()
                 self?.rootView.searchBarLabel.setText("원하는 장소를 찾아보세요", style: .title1, color: .grayscale7)
-                
                 self?.rootView.eraseButton.isHidden = true
+                self?.rootView.searchImageView.isHidden = false
             }
             .store(in: cancelBag)
         

--- a/Roomie/Roomie/Presentation/Map/ViewModel/MapViewModel.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewModel/MapViewModel.swift
@@ -14,7 +14,8 @@ final class MapViewModel {
     
     private var houseID: Int?
     
-    private let mapDataSubject = CurrentValueSubject<MapResponseDTO?, Never>(nil)
+    let mapDataSubject = CurrentValueSubject<MapResponseDTO?, Never>(nil)
+    private let pinnedInfoSubject = PassthroughSubject<(Int, Bool), Never>()
     
     init(service: MapServiceProtocol, builder: MapRequestDTO.Builder) {
         self.service = service
@@ -27,6 +28,7 @@ extension MapViewModel: ViewModelType {
         let viewWillAppear: AnyPublisher<Void, Never>
         let markerDidSelect: AnyPublisher<Int, Never>
         let eraseButtonDidTap: AnyPublisher<Void, Never>
+        let pinnedHouseID: AnyPublisher<Int, Never>
     }
     
     struct Output {
@@ -34,6 +36,7 @@ extension MapViewModel: ViewModelType {
         let markerDetailInfo: AnyPublisher<MarkerDetailInfo, Never>
         let mapListData: AnyPublisher<MapResponseDTO, Never>
         let defaultLocationInfo: AnyPublisher<(Double, Double), Never>
+        let pinnedInfo: AnyPublisher<(Int, Bool), Never>
     }
     
     func transform(from input: Input, cancelBag: CancelBag) -> Output {
@@ -57,6 +60,16 @@ extension MapViewModel: ViewModelType {
                 self.fetchMapData(request: builder.build())
             }
             .store(in: cancelBag)
+        
+        input.pinnedHouseID
+            .sink { [weak self] houseID in
+                guard let self = self else { return }
+                self.updatePinnedHouse(houseID: houseID)
+            }
+            .store(in: cancelBag)
+        
+        let pinnedInfo = pinnedInfoSubject
+            .eraseToAnyPublisher()
         
         let mapListData = mapDataSubject
             .compactMap { $0 }
@@ -97,7 +110,8 @@ extension MapViewModel: ViewModelType {
             markersInfo: markersInfo,
             markerDetailInfo: markerDetailInfo,
             mapListData: mapListData,
-            defaultLocationInfo: defaultLocationInfo
+            defaultLocationInfo: defaultLocationInfo,
+            pinnedInfo: pinnedInfo
         )
     }
 }
@@ -109,6 +123,18 @@ private extension MapViewModel {
                 guard let responseBody = try await service.fetchMapData(request: request),
                       let data = responseBody.data else { return }
                 mapDataSubject.send(data)
+            } catch {
+                print(">>> \(error.localizedDescription) : \(#function)")
+            }
+        }
+    }
+    
+    func updatePinnedHouse(houseID: Int) {
+        Task {
+            do {
+                guard let responseBody = try await service.updatePinnedHouse(houseID: houseID),
+                      let data = responseBody.data else { return }
+                pinnedInfoSubject.send((houseID, data.isPinned))
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }

--- a/Roomie/Roomie/Presentation/WishList/ViewController/WishListViewController.swift
+++ b/Roomie/Roomie/Presentation/WishList/ViewController/WishListViewController.swift
@@ -114,7 +114,7 @@ private extension WishListViewController {
             .sink { [weak self] (houseID, isPinned) in
                 guard let self = self else { return }
 
-                if let index = self.viewModel.wishListData.firstIndex(where: { $0.houseID == houseID }) {
+                if let index = self.viewModel.wishListDataSubject.value?.pinnedHouses.firstIndex(where: { $0.houseID == houseID }) {
                     let indexPath = IndexPath(item: index, section: 0)
                     if let cell = self.rootView.wishListCollectionView.cellForItem(at: indexPath) as? HouseListCollectionViewCell {
                         cell.updateWishButton(isPinned: isPinned)
@@ -216,7 +216,7 @@ extension WishListViewController: UICollectionViewDelegateFlowLayout {
         _ collectionView: UICollectionView,
         didSelectItemAt indexPath: IndexPath
     ) {
-        let houseID = viewModel.wishListData[indexPath.item].houseID
+        guard let houseID = viewModel.wishListDataSubject.value?.pinnedHouses[indexPath.item].houseID else { return }
         didTapHouseSubject.send(houseID)
     }
     

--- a/Roomie/Roomie/Presentation/WishList/ViewController/WishListViewController.swift
+++ b/Roomie/Roomie/Presentation/WishList/ViewController/WishListViewController.swift
@@ -24,7 +24,6 @@ final class WishListViewController: BaseViewController {
     
     private let viewWillAppearSubject = PassthroughSubject<Void, Never>()
     private let pinnedHouseIDSubject = PassthroughSubject<Int, Never>()
-    private let didTapHouseSubject = PassthroughSubject<Int, Never>()
     
     private lazy var dataSource = createDiffableDataSource()
     
@@ -91,8 +90,7 @@ private extension WishListViewController {
     func bindViewModel() {
         let input = WishListViewModel.Input(
             viewWillAppear: viewWillAppearSubject.eraseToAnyPublisher(),
-            pinnedHouseIDSubject: pinnedHouseIDSubject.eraseToAnyPublisher(),
-            tappedHouseIDSubject: didTapHouseSubject.eraseToAnyPublisher()
+            pinnedHouseIDSubject: pinnedHouseIDSubject.eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
@@ -123,20 +121,6 @@ private extension WishListViewController {
                 if isPinned == false {
                     Toast().show(message: "찜 목록에서 삭제되었어요", inset: 32, view: rootView)
                 }
-            }
-            .store(in: cancelBag)
-        
-        output.tappedInfo
-            .receive(on: RunLoop.main)
-            .sink { [weak self] houseID in
-                guard let self = self else { return }
-                self.houseID = houseID
-                
-                let houseDetailViewController = HouseDetailViewController(
-                    viewModel: HouseDetailViewModel(houseID: houseID, service: HousesService())
-                )
-                houseDetailViewController.hidesBottomBarWhenPushed = true
-                self.navigationController?.pushViewController(houseDetailViewController, animated: true)
             }
             .store(in: cancelBag)
     }
@@ -217,7 +201,11 @@ extension WishListViewController: UICollectionViewDelegateFlowLayout {
         didSelectItemAt indexPath: IndexPath
     ) {
         guard let houseID = viewModel.wishListDataSubject.value?.pinnedHouses[indexPath.item].houseID else { return }
-        didTapHouseSubject.send(houseID)
+        let houseDetailViewController = HouseDetailViewController(
+            viewModel: HouseDetailViewModel(houseID: houseID, service: HousesService())
+        )
+        houseDetailViewController.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(houseDetailViewController, animated: true)
     }
     
     func collectionView(

--- a/Roomie/Roomie/Presentation/WishList/ViewController/WishListViewController.swift
+++ b/Roomie/Roomie/Presentation/WishList/ViewController/WishListViewController.swift
@@ -32,7 +32,6 @@ final class WishListViewController: BaseViewController {
     final let contentInterSpacing: CGFloat = 4
     final let contentInset = UIEdgeInsets(top: 12, left: 16, bottom: 24, right: 16)
     
-    var houseID: Int = 0
     
     // MARK: - Initializer
     
@@ -59,6 +58,9 @@ final class WishListViewController: BaseViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        updateSeletedCell()
         viewWillAppearSubject.send()
     }
     
@@ -112,9 +114,12 @@ private extension WishListViewController {
             .sink { [weak self] (houseID, isPinned) in
                 guard let self = self else { return }
 
-                if let index = self.viewModel.wishListDataSubject.value?.pinnedHouses.firstIndex(where: { $0.houseID == houseID }) {
+                if let index = self.viewModel.wishListDataSubject.value?.pinnedHouses.firstIndex(
+                    where: { $0.houseID == houseID }
+                ) {
                     let indexPath = IndexPath(item: index, section: 0)
-                    if let cell = self.rootView.wishListCollectionView.cellForItem(at: indexPath) as? HouseListCollectionViewCell {
+                    if let cell = self.rootView.wishListCollectionView.cellForItem(at: indexPath)
+                        as? HouseListCollectionViewCell {
                         cell.updateWishButton(isPinned: isPinned)
                     }
                 }
@@ -166,6 +171,15 @@ private extension WishListViewController {
         snapshot.appendSections([0])
         snapshot.appendItems(data, toSection: 0)
         dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
+    func updateSeletedCell() {
+        for index in rootView.wishListCollectionView.indexPathsForVisibleItems {
+            if let cell = rootView.wishListCollectionView.cellForItem(at: index) as?
+                HouseListCollectionViewCell {
+                cell.isSelected = false
+            }
+        }
     }
 }
 

--- a/Roomie/Roomie/Presentation/WishList/ViewModel/WishListViewModel.swift
+++ b/Roomie/Roomie/Presentation/WishList/ViewModel/WishListViewModel.swift
@@ -14,11 +14,9 @@ final class WishListViewModel {
     
     private let service: WishListServiceProtocol
     
-    private let wishListDataSubject = PassthroughSubject<WishListResponseDTO, Never>()
+    let wishListDataSubject = CurrentValueSubject<WishListResponseDTO?, Never>(nil)
     let pinnedInfoDataSubject = PassthroughSubject<(Int, Bool), Never>()
     private let didTapHouseDataSubject = PassthroughSubject<Int, Never>()
-    
-    private(set) var wishListData: [WishHouse] = []
     
     init(service: WishListServiceProtocol) {
         self.service = service
@@ -58,6 +56,7 @@ extension WishListViewModel: ViewModelType {
             .store(in: cancelBag)
         
         let wishListData = wishListDataSubject
+            .compactMap { $0 }
             .map { house in
                 house.pinnedHouses.map { data in
                     WishHouse(
@@ -75,9 +74,6 @@ extension WishListViewModel: ViewModelType {
                     )
                 }
             }
-            .handleEvents(receiveOutput: { [weak self] list in
-                self?.wishListData = list
-            })
             .eraseToAnyPublisher()
         
         let pinnedInfoData = pinnedInfoDataSubject
@@ -109,11 +105,7 @@ private extension WishListViewModel {
             do {
                 guard let responseBody = try await service.updatePinnedHouse(houseID: houseID),
                       let data = responseBody.data else { return }
-                
-                if let index = self.wishListData.firstIndex(where: { $0.houseID == houseID }) {
-                    self.wishListData[index].isPinned = data.isPinned
-                    self.pinnedInfoDataSubject.send((houseID, data.isPinned))
-                }
+                self.pinnedInfoDataSubject.send((houseID, data.isPinned))
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }

--- a/Roomie/Roomie/Presentation/WishList/ViewModel/WishListViewModel.swift
+++ b/Roomie/Roomie/Presentation/WishList/ViewModel/WishListViewModel.swift
@@ -27,13 +27,11 @@ extension WishListViewModel: ViewModelType {
     struct Input {
         let viewWillAppear: AnyPublisher<Void, Never>
         let pinnedHouseIDSubject: AnyPublisher<Int, Never>
-        let tappedHouseIDSubject: AnyPublisher<Int, Never>
     }
     
     struct Output {
         let wishList: AnyPublisher<[WishHouse], Never>
         let pinnedInfo: AnyPublisher<(Int,Bool), Never>
-        let tappedInfo: AnyPublisher<Int, Never>
     }
     
     func transform(from input: Input, cancelBag: CancelBag) -> Output {
@@ -46,12 +44,6 @@ extension WishListViewModel: ViewModelType {
         input.pinnedHouseIDSubject
             .sink { [weak self] houseID in
                 self?.updatePinnedHouse(houseID: houseID)
-            }
-            .store(in: cancelBag)
-        
-        input.tappedHouseIDSubject
-            .sink { [weak self] houseID in
-                self?.didTapHouseDataSubject.send(houseID)
             }
             .store(in: cancelBag)
         
@@ -81,8 +73,7 @@ extension WishListViewModel: ViewModelType {
         
         return Output(
             wishList: wishListData,
-            pinnedInfo: pinnedInfoData,
-            tappedInfo: didTapHouseDataSubject.eraseToAnyPublisher()
+            pinnedInfo: pinnedInfoData
         )
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #이슈번호

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 지도 리스트 뷰의 찜 API를 구현했어요.
- 지도 리스트 뷰의 화면전환 로직을 구현했어요.
- 홈 뷰와 찜 리스트 뷰의 찜 API 로직과 화면 전환 로직을 수정했어요.

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 지도 리스트 뷰 | <img src = "https://github.com/user-attachments/assets/200ccee3-a0b8-429b-8998-0f9246d728bf" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
얘들아 다들 수고가 많다 조금만 힘내잉 ⋯