### PR TITLE
[feat/#139] 서비스 분리 및 찜 API 구현 및 화면 연결

### DIFF
--- a/Roomie/Roomie/Network/Service/HousesService.swift
+++ b/Roomie/Roomie/Network/Service/HousesService.swift
@@ -40,16 +40,6 @@ final class HousesService {
     }
 }
 
-extension HousesService: WishListServiceProtocol {
-    func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>? {
-        return try await self.request(with: .updatePinnedHouse(houseID: houseID))
-    }
-    
-    func fetchWishListData() async throws -> BaseResponseBody<WishListResponseDTO>? {
-        return try await self.request(with: .fetchWishLishData)
-    }
-}
-
 extension HousesService: HouseDetailServiceProtocol {
     func applyTour(request: TourRequestDTO, roomID: Int) async throws -> BaseResponseBody<TourResponseDTO>? {
         return try await self.request(with: .applyTour(request: request, roomID: roomID))
@@ -71,57 +61,7 @@ extension HousesService: HouseDetailServiceProtocol {
         return try await self.request(with: .fetchHouseDetailData(houseID: houseID))
     }
     
-    // TODO: 찜 API 추가
-}
-
-extension HousesService: MoodListServiceProtocol {
-    func fetchMoodListData(moodTag: String) async throws -> BaseResponseBody<MoodListResponseDTO>? {
-        return try await self.request(with: .fetchMoodListData(moodTag: moodTag))
-    }
-    
-    // TODO: 찜 API 추가
-}
-
-final class MockHouseService: WishListServiceProtocol {
     func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>? {
-        let mockData: PinnedResponseDTO = PinnedResponseDTO(isPinned: false)
-        return BaseResponseBody(code: 200, message: "", data: mockData)
-    }
-    
-    func fetchWishListData() async throws -> BaseResponseBody<WishListResponseDTO>? {
-        let mockData: WishListResponseDTO = WishListResponseDTO(pinnedHouses: [])
-        return BaseResponseBody(code: 200, message: "", data: mockData)
-    }
-    
-    func fetchMoodListData(moodTag: String) async throws -> BaseResponseBody<MoodListResponseDTO>? {
-        let mockData: MoodListResponseDTO = MoodListResponseDTO(
-            moodTag: "#차분한",
-            houses: [
-            MoodHouse(
-                houseID: 1,
-                monthlyRent: "30~50",
-                deposit: "200~300",
-                occupancyTypes: "1,2인실",
-                location: "서대문구 연희동",
-                genderPolicy: "여성전용",
-                locationDescription: "자이아파트",
-                isPinned: false,
-                contractTerm: 6,
-                mainImageURL: ""
-            ),
-            MoodHouse(
-                houseID: 2,
-                monthlyRent: "30~50",
-                deposit: "200~300",
-                occupancyTypes: "1,2,3인실",
-                location: "서대문구 대현동",
-                genderPolicy: "성별무관",
-                locationDescription: "자이아파트",
-                isPinned: true,
-                contractTerm: 6,
-                mainImageURL: ""
-            )
-        ])
-        return BaseResponseBody(code: 200, message: "", data: mockData)
+        return try await self.request(with: .updatePinnedHouse(houseID: houseID))
     }
 }

--- a/Roomie/Roomie/Network/Service/MoodListService.swift
+++ b/Roomie/Roomie/Network/Service/MoodListService.swift
@@ -1,0 +1,90 @@
+//
+//  MoodListService.swift
+//  Roomie
+//
+//  Created by 예삐 on 1/24/25.
+//
+
+import Foundation
+
+import Moya
+
+final class MoodListService {
+    let provider: MoyaProvider<MoodListTargetType>
+    
+    init(provider: MoyaProvider<MoodListTargetType> = MoyaProvider(plugins: [MoyaLoggingPlugin()])) {
+        self.provider = provider
+    }
+    
+    func request<T: ResponseModelType>(
+        with request: MoodListTargetType
+    ) async throws -> BaseResponseBody<T>? {
+        return try await withCheckedThrowingContinuation {
+            continuation in provider.request(request) {
+                result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decodedData = try JSONDecoder().decode(
+                            BaseResponseBody<T>.self, from: response.data
+                        )
+                        continuation.resume(returning: decodedData)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+extension MoodListService: MoodListServiceProtocol {
+    func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>? {
+        return try await self.request(with: .updatePinnedHouse(houseID: houseID))
+    }
+    
+    func fetchMoodListData(moodTag: String) async throws -> BaseResponseBody<MoodListResponseDTO>? {
+        return try await self.request(with: .fetchMoodListData(moodTag: moodTag))
+    }
+}
+
+final class MockMoodListService: MoodListServiceProtocol {
+    func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>? {
+        let mockData: PinnedResponseDTO = PinnedResponseDTO(isPinned: false)
+        return BaseResponseBody(code: 200, message: "", data: mockData)
+    }
+    
+    func fetchMoodListData(moodTag: String) async throws -> BaseResponseBody<MoodListResponseDTO>? {
+        let mockData: MoodListResponseDTO = MoodListResponseDTO(
+            moodTag: "#차분한",
+            houses: [
+            MoodHouse(
+                houseID: 1,
+                monthlyRent: "30~50",
+                deposit: "200~300",
+                occupancyTypes: "1,2인실",
+                location: "서대문구 연희동",
+                genderPolicy: "여성전용",
+                locationDescription: "자이아파트",
+                isPinned: false,
+                contractTerm: 6,
+                mainImageURL: ""
+            ),
+            MoodHouse(
+                houseID: 2,
+                monthlyRent: "30~50",
+                deposit: "200~300",
+                occupancyTypes: "1,2,3인실",
+                location: "서대문구 대현동",
+                genderPolicy: "성별무관",
+                locationDescription: "자이아파트",
+                isPinned: true,
+                contractTerm: 6,
+                mainImageURL: ""
+            )
+        ])
+        return BaseResponseBody(code: 200, message: "", data: mockData)
+    }
+}

--- a/Roomie/Roomie/Network/Service/WishListService.swift
+++ b/Roomie/Roomie/Network/Service/WishListService.swift
@@ -1,0 +1,63 @@
+//
+//  WishListService.swift
+//  Roomie
+//
+//  Created by 예삐 on 1/24/25.
+//
+
+import Foundation
+
+import Moya
+
+final class WishListService {
+    let provider: MoyaProvider<WishListTargetType>
+    
+    init(provider: MoyaProvider<WishListTargetType> = MoyaProvider(plugins: [MoyaLoggingPlugin()])) {
+        self.provider = provider
+    }
+    
+    func request<T: ResponseModelType>(
+        with request: WishListTargetType
+    ) async throws -> BaseResponseBody<T>? {
+        return try await withCheckedThrowingContinuation {
+            continuation in provider.request(request) {
+                result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decodedData = try JSONDecoder().decode(
+                            BaseResponseBody<T>.self, from: response.data
+                        )
+                        continuation.resume(returning: decodedData)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+extension WishListService: WishListServiceProtocol {
+    func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>? {
+        return try await self.request(with: .updatePinnedHouse(houseID: houseID))
+    }
+    
+    func fetchWishListData() async throws -> BaseResponseBody<WishListResponseDTO>? {
+        return try await self.request(with: .fetchWishLishData)
+    }
+}
+
+final class MockWishListService: WishListServiceProtocol {
+    func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>? {
+        let mockData: PinnedResponseDTO = PinnedResponseDTO(isPinned: false)
+        return BaseResponseBody(code: 200, message: "", data: mockData)
+    }
+    
+    func fetchWishListData() async throws -> BaseResponseBody<WishListResponseDTO>? {
+        let mockData: WishListResponseDTO = WishListResponseDTO(pinnedHouses: [])
+        return BaseResponseBody(code: 200, message: "", data: mockData)
+    }
+}

--- a/Roomie/Roomie/Network/TargetType/HousesTargetType.swift
+++ b/Roomie/Roomie/Network/TargetType/HousesTargetType.swift
@@ -10,12 +10,10 @@ import Foundation
 import Moya
 
 enum HousesTargetType {
-    case fetchWishLishData
     case fetchHouseDetailData(houseID: Int)
-    case fetchMoodListData(moodTag: String)
-    case updatePinnedHouse(houseID: Int)
     case fetchHouseDetailImagesData(houseID: Int)
     case fetchHouseDetailRoomsData(houseID: Int)
+    case updatePinnedHouse(houseID: Int)
     case applyTour(request: TourRequestDTO, roomID: Int)
 }
 
@@ -26,27 +24,22 @@ extension HousesTargetType: TargetType {
     
     var path: String {
         switch self {
-        case .fetchMoodListData:
-            return "/houses"
-        case .fetchWishLishData:
-            return "/houses/pins"
         case .fetchHouseDetailData(houseID: let houseID):
             return "/houses/\(houseID)/details"
-        case .updatePinnedHouse(houseID: let houseID):
-            return "/houses/\(houseID)/pins"
         case .fetchHouseDetailImagesData(houseID: let houseID):
             return "/houses/\(houseID)/details/images"
         case .fetchHouseDetailRoomsData(houseID: let houseID):
             return "/houses/\(houseID)/details/rooms"
-        case .applyTour(request: let request, roomID: let roomID):
+        case .updatePinnedHouse(houseID: let houseID):
+            return "/houses/\(houseID)/pins"
+        case .applyTour(request: _, roomID: let roomID):
             return "/rooms/\(roomID)/tour-requests"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .fetchWishLishData, .fetchHouseDetailData: return .get
-        case .fetchMoodListData, .fetchHouseDetailImagesData, .fetchHouseDetailRoomsData: return .get
+        case .fetchHouseDetailData, .fetchHouseDetailImagesData, .fetchHouseDetailRoomsData: return .get
         case .updatePinnedHouse: return .patch
         case .applyTour: return .post
         }
@@ -54,16 +47,11 @@ extension HousesTargetType: TargetType {
     
     var task: Moya.Task {
         switch self {
-        case .fetchWishLishData, .fetchHouseDetailData, .updatePinnedHouse:
+        case .fetchHouseDetailData, .updatePinnedHouse:
             return .requestPlain
         case .fetchHouseDetailImagesData, .fetchHouseDetailRoomsData:
             return .requestPlain
-        case .fetchMoodListData(moodTag: let moodTag):
-            return .requestParameters(
-                parameters: ["moodTag": moodTag],
-                encoding: URLEncoding.queryString
-            )
-        case .applyTour(request: let request, roomID: let roomID):
+        case .applyTour(request: let request, roomID: _):
             return .requestJSONEncodable(request)
         }
     }

--- a/Roomie/Roomie/Network/TargetType/MoodListTargetType.swift
+++ b/Roomie/Roomie/Network/TargetType/MoodListTargetType.swift
@@ -1,0 +1,53 @@
+//
+//  MoodListTargetType.swift
+//  Roomie
+//
+//  Created by 예삐 on 1/24/25.
+//
+
+import Foundation
+
+import Moya
+
+enum MoodListTargetType {
+    case fetchMoodListData(moodTag: String)
+    case updatePinnedHouse(houseID: Int)
+}
+
+extension MoodListTargetType: TargetType {
+    var baseURL: URL {
+        return URL(string: "\(Environment.baseURL)/v1")!
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchMoodListData:
+            return "/houses"
+        case .updatePinnedHouse(houseID: let houseID):
+            return "/houses/\(houseID)/pins"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchMoodListData: return .get
+        case .updatePinnedHouse: return .patch
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .fetchMoodListData(moodTag: let moodTag):
+            return .requestParameters(
+                parameters: ["moodTag": moodTag],
+                encoding: URLEncoding.queryString
+            )
+        case .updatePinnedHouse:
+            return .requestPlain
+        }
+    }
+    
+    var headers: [String : String]? {
+        return ["Content-Type": "application/json"]
+    }
+}

--- a/Roomie/Roomie/Network/TargetType/WishListTargetType.swift
+++ b/Roomie/Roomie/Network/TargetType/WishListTargetType.swift
@@ -1,0 +1,45 @@
+//
+//  WishListTargetType.swift
+//  Roomie
+//
+//  Created by 예삐 on 1/24/25.
+//
+
+import Foundation
+
+import Moya
+
+enum WishListTargetType {
+    case fetchWishLishData
+    case updatePinnedHouse(houseID: Int)
+}
+
+extension WishListTargetType: TargetType {
+    var baseURL: URL {
+        return URL(string: "\(Environment.baseURL)/v1")!
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchWishLishData:
+            return "/houses/pins"
+        case .updatePinnedHouse(houseID: let houseID):
+            return "/houses/\(houseID)/pins"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchWishLishData: return .get
+        case .updatePinnedHouse: return .patch
+        }
+    }
+    
+    var task: Moya.Task {
+        return .requestPlain
+    }
+    
+    var headers: [String : String]? {
+        return ["Content-Type": "application/json"]
+    }
+}

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -296,7 +296,7 @@ private extension HomeViewController {
     @objc
     func wishLishButtonDidTap() {
         let wishListViewController = WishListViewController(
-            viewModel: WishListViewModel(service: HousesService())
+            viewModel: WishListViewModel(service: WishListService())
         )
         self.navigationController?.pushViewController(wishListViewController, animated: true)
     }

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -75,6 +75,8 @@ final class HomeViewController: BaseViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
         updateSeletedCell()
         setHomeNavigationBarStatus()
         viewWillAppearSubject.send()

--- a/Roomie/Roomie/Presentation/MoodList/ViewController/MoodListViewController.swift
+++ b/Roomie/Roomie/Presentation/MoodList/ViewController/MoodListViewController.swift
@@ -40,7 +40,7 @@ final class MoodListViewController: BaseViewController {
     init(moodType: MoodType) {
         self.moodType = moodType
         self.moodNavibarTitle = moodType.title
-        self.viewModel = MoodListViewModel(service: HousesService())
+        self.viewModel = MoodListViewModel(service: MoodListService())
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/Roomie/Roomie/Presentation/MoodList/ViewController/MoodListViewController.swift
+++ b/Roomie/Roomie/Presentation/MoodList/ViewController/MoodListViewController.swift
@@ -69,6 +69,8 @@ final class MoodListViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        updateSeletedCell()
         moodListTypeSubject.send(moodType.title)
     }
     
@@ -194,6 +196,15 @@ private extension MoodListViewController {
         snapshot.appendItems(data, toSection: 0)
         dataSource.apply(snapshot, animatingDifferences: true)
     }
+    
+    func updateSeletedCell() {
+        for index in rootView.moodListCollectionView.indexPathsForVisibleItems {
+            if let cell = rootView.moodListCollectionView.cellForItem(at: index) as?
+                HouseListCollectionViewCell {
+                cell.isSelected = false
+            }
+        }
+    }
 }
 
 // MARK: - UICollectionViewDelegateFlowLayout
@@ -227,7 +238,12 @@ extension MoodListViewController: UICollectionViewDelegateFlowLayout {
         _ collectionView: UICollectionView,
         didSelectItemAt indexPath: IndexPath
     ) {
-        // TODO: 상세매물 페이지와 연결
+        guard let houseID = viewModel.moodListDataSubject.value?.houses[indexPath.item].houseID else { return }
+        let houseDetailViewController = HouseDetailViewController(
+            viewModel: HouseDetailViewModel(houseID: houseID, service: HousesService())
+        )
+        houseDetailViewController.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(houseDetailViewController, animated: true)
     }
     
     func collectionView(

--- a/Roomie/Roomie/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/Roomie/Roomie/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -127,7 +127,7 @@ extension MyPageViewController: UICollectionViewDelegate {
         switch indexPath.section {
         case 0:
             if indexPath.row == 0 {
-                let wishListViewController = WishListViewController(viewModel: WishListViewModel(service: HousesService()))
+                let wishListViewController = WishListViewController(viewModel: WishListViewModel(service: WishListService()))
                 wishListViewController.hidesBottomBarWhenPushed = true
                 self.navigationController?
                     .pushViewController(wishListViewController, animated: true)


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #139

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 타겟타입과 서비스를 분리했어요.
- 분위기별 리스트의 찜 API를 구현했어요.
- 분위기별 리스트와 상세 매물 뷰와의 화면 연결을 구현했어요.

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 분위기별 리스트 | <img src = "https://github.com/user-attachments/assets/15586b92-45d8-4a0f-bc69-1d1141fdb0f1" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
끝이 보여 얘들 아 .. ㅠㅠ