### PR TITLE
[feat/#144] 카드 뷰와 매물 상세 뷰 화면 연결

### DIFF
--- a/Roomie/Roomie/Presentation/Map/View/MapDetialCardView.swift
+++ b/Roomie/Roomie/Presentation/Map/View/MapDetialCardView.swift
@@ -27,7 +27,8 @@ final class MapDetialCardView: BaseView {
     private let moodTagView = UIView()
     let moodTagLabel = UILabel()
     
-    let arrowButton = UIButton()
+    let arrowImageView = UIImageView()
+    let nextButton = UIButton()
     
     // MARK: - UISetting
 
@@ -72,8 +73,8 @@ final class MapDetialCardView: BaseView {
             $0.setText(style: .body4, color: .grayscale9)
         }
         
-        arrowButton.do {
-            $0.setImage(.icnArrowRightLine40, for: .normal)
+        arrowImageView.do {
+            $0.image = .icnArrowRightLine40
         }
     }
     
@@ -84,7 +85,8 @@ final class MapDetialCardView: BaseView {
             genderOccupancyLabel,
             locationLabel,
             moodTagView,
-            arrowButton
+            arrowImageView,
+            nextButton
         )
         subtitleStackView.addArrangedSubviews(
             depositLabel,
@@ -130,10 +132,14 @@ final class MapDetialCardView: BaseView {
             $0.leading.trailing.equalToSuperview().inset(8)
         }
         
-        arrowButton.snp.makeConstraints {
+        arrowImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(8)
             $0.trailing.equalToSuperview().inset(8)
             $0.size.equalTo(40)
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
     }
 }

--- a/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewController/MapViewController.swift
@@ -25,7 +25,7 @@ final class MapViewController: BaseViewController {
     private var selectedMarker: NMFMarker?
     
     private let viewWillAppearSubject = CurrentValueSubject<Void, Never>(())
-    private let markerDidSelectSubject = PassthroughSubject<Int, Never>()
+    private let markerDidSelectSubject = CurrentValueSubject<Int, Never>(0)
     private let eraseButtonDidTapSubject = PassthroughSubject<Void, Never>()
     
     // MARK: - Initializer
@@ -113,10 +113,17 @@ final class MapViewController: BaseViewController {
             }
             .store(in: cancelBag)
         
-        rootView.mapDetailCardView.arrowButton
+        rootView.mapDetailCardView.nextButton
             .tapPublisher
-            .sink {
-                // TODO: 매물 상세 뷰 화면 연결
+            .sink { [weak self] in
+                let houseDetailViewController = HouseDetailViewController(
+                    viewModel: HouseDetailViewModel(
+                        houseID: self?.markerDidSelectSubject.value ?? 0,
+                        service: HousesService()
+                    )
+                )
+                houseDetailViewController.hidesBottomBarWhenPushed = true
+                self?.navigationController?.pushViewController(houseDetailViewController, animated: true)
             }
             .store(in: cancelBag)
     }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #144

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 카드 뷰의 전체를 탭했을 때 화면 전환이 될 수 있도록 UI를 수정했어요.
- 카드 뷰와 매물 상세 뷰의 화면을 연결했어요.

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 화면 연결 | <img src = "https://github.com/user-attachments/assets/63a0b6e7-749c-4a0d-a94f-7fb02606b2b8" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
하⋯ 하하