### PR TITLE
[feat/#141] 상세 매물 찜 API 구현

### DIFF
--- a/Roomie/Roomie/Global/Components/CheckIconLabel.swift
+++ b/Roomie/Roomie/Global/Components/CheckIconLabel.swift
@@ -83,3 +83,9 @@ private extension CheckIconLabel {
         ruleLabel.setText(text, style: .body1, color: .grayscale12)
     }
 }
+
+extension CheckIconLabel {
+    func updateText(_ text: String) {
+        ruleLabel.updateText(text)
+    }
+}

--- a/Roomie/Roomie/Presentation/HouseDetail/ServiceProtocol/HouseDetailServiceProtocol.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ServiceProtocol/HouseDetailServiceProtocol.swift
@@ -19,5 +19,5 @@ protocol HouseDetailServiceProtocol {
     
     func applyTour(request: TourRequestDTO, roomID: Int) async throws -> BaseResponseBody<TourResponseDTO>?
     
-    // TODO: 찜 API 추가
+    func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>?
 }

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
@@ -19,9 +19,9 @@ final class HouseDetailView: BaseView {
     
     // HousePhoto Section
     let photoImageView = UIImageView()
-    private let roundedTopView = UIView()
     
     // HouseInfo Section
+    private let houseInfoBackView = UIView()
     private let nameBackView = UIView()
     let nameLabel = UILabel()
     let titleLabel = UILabel()
@@ -78,9 +78,9 @@ final class HouseDetailView: BaseView {
             $0.clipsToBounds = true
         }
         
-        roundedTopView.do {
+        houseInfoBackView.do {
             $0.backgroundColor = .grayscale1
-            $0.roundCorners(cornerRadius: 12, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
+            $0.roundCorners(cornerRadius: 16, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         }
         
         nameBackView.do {
@@ -197,7 +197,7 @@ final class HouseDetailView: BaseView {
         
         contentView.addSubviews(
             photoImageView,
-            roundedTopView,
+            houseInfoBackView,
             nameBackView,
             titleLabel,
             firstIconLabelStackView,
@@ -256,10 +256,10 @@ final class HouseDetailView: BaseView {
             $0.height.equalTo(Screen.height(316))
         }
         
-        roundedTopView.snp.makeConstraints {
-            $0.bottom.equalTo(nameBackView.snp.top)
+        houseInfoBackView.snp.makeConstraints {
+            $0.top.equalTo(photoImageView.snp.bottom).offset(-20)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(Screen.height(20))
+            $0.bottom.equalTo(lookInsidePhotoButton.snp.bottom).offset(20)
         }
         
         nameBackView.snp.makeConstraints {

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
@@ -61,7 +61,7 @@ final class HouseDetailView: BaseView {
     // bottom Button
     private let bottomButtonbackView = UIView()
     private let bottomButtonSeparatorView = UIView()
-    let pinnedButton = RoomieIconButton(imageName: "icn_heart_24_normal", border: true)
+    let wishListButton = RoomieIconButton(imageName: "icn_heart_24_normal", border: true)
     let contactButton = RoomieIconButton(imageName: "icn_inquire_24", border: true)
     let tourApplyButton = RoomieButton(title: "투어신청하기")
     
@@ -233,7 +233,7 @@ final class HouseDetailView: BaseView {
         
         bottomButtonbackView.addSubviews(
             bottomButtonSeparatorView,
-            pinnedButton,
+            wishListButton,
             contactButton,
             tourApplyButton
         )
@@ -389,18 +389,18 @@ final class HouseDetailView: BaseView {
             $0.height.equalTo(1)
         }
         
-        pinnedButton.snp.makeConstraints {
+        wishListButton.snp.makeConstraints {
             $0.top.equalToSuperview().inset(12)
             $0.leading.equalToSuperview().inset(20)
             $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).offset(-12)
-            $0.width.equalTo(pinnedButton.snp.height)
+            $0.width.equalTo(wishListButton.snp.height)
         }
         
         contactButton.snp.makeConstraints {
             $0.top.equalToSuperview().inset(12)
-            $0.leading.equalTo(pinnedButton.snp.trailing).offset(8)
+            $0.leading.equalTo(wishListButton.snp.trailing).offset(8)
             $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).offset(-12)
-            $0.width.equalTo(pinnedButton.snp.height)
+            $0.width.equalTo(wishListButton.snp.height)
         }
         
         tourApplyButton.snp.makeConstraints {

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailSheetViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailSheetViewController.swift
@@ -77,7 +77,8 @@ private extension HouseDetailSheetViewController {
             houseDetailViewWillAppear: Just(()).eraseToAnyPublisher(),
             bottomSheetViewWillAppear: viewWillAppearSubject.eraseToAnyPublisher(),
             buttonIndexSubject: buttonIndexSubject.eraseToAnyPublisher(),
-            tourApplyButtonTapSubject: tourApplyButtonTapSubject.eraseToAnyPublisher()
+            tourApplyButtonTapSubject: tourApplyButtonTapSubject.eraseToAnyPublisher(),
+            wishListButtonSubject: PassthroughSubject<Void, Never>().eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
@@ -168,11 +168,12 @@ private extension HouseDetailViewController {
             .receive(on: RunLoop.main)
             .sink { [weak self] isPinned in
                 guard let self else { return }
-                rootView.wishListButton
-                    .setImage(
-                        isPinned ? .icnHeart24Active : .icnHeart24Normal,
-                        for: .normal
-                    )
+                if isPinned {
+                    rootView.wishListButton.setImage(.icnHeart24Active, for: .normal)
+                } else {
+                    rootView.wishListButton.setImage(.icnHeart24Normal, for: .normal)
+                    Toast().show(message: "찜 목록에서 삭제되었어요", inset: Screen.height(120), view: rootView)
+                }
             }
             .store(in: cancelBag)
         

--- a/Roomie/Roomie/Presentation/Tour/View/TourCheckView.swift
+++ b/Roomie/Roomie/Presentation/Tour/View/TourCheckView.swift
@@ -20,7 +20,7 @@ final class TourCheckView: BaseView {
     let houseNameLabel = UILabel()
     
     private let roomTitleLabel = UILabel()
-    let roomNameLabel = UILabel()
+    let roomNameLabel = CheckIconLabel(text: "")
     
     let nextButton = RoomieButton(title: "이 방이 맞아요")
         
@@ -36,15 +36,11 @@ final class TourCheckView: BaseView {
         }
         
         houseNameLabel.do {
-            $0.setText("해피쉐어 100호점 (건대점)", style: .body1, color: .grayscale12)
+            $0.setText(style: .body1, color: .grayscale12)
         }
         
         roomTitleLabel.do {
             $0.setText("대상", style: .body2, color: .grayscale7)
-        }
-        
-        roomNameLabel.do {
-            $0.setText("1A (싱글침대)", style: .body1, color: .grayscale12)
         }
     }
     


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #141 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 상세 페이지 찜 API를 구현했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| A 기능 | <img src = "https://github.com/user-attachments/assets/ce001d41-4fb7-452d-8393-7030e6c13daa" width ="250"> | <img src = "https://github.com/user-attachments/assets/015cc7f3-95c4-4d17-8ad2-f7f515e9f6a6" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

- 저희 찜 토스트 뜨는 것 중에 찜목록뷰에서 토스트가 살짝 높게 뜨는 거 같은데 한번 확인해봅죠!
- 아 상세 페이지에서는 토스트에 그냥 inset넣으면 기기마다 넘 달라서 Screen유틸코드 써서 inset잡았어요! 다른 뷰도 한번씩 보고 필요하면 추가하면 좋을 거 같습니다
- 하.. 진짜 ㄹㅇ 무수면 챌린지 ㅋㅋ ㅠ