### PR TITLE
[feat/#152] Stretch Header 구현

### DIFF
--- a/Roomie/Roomie/Network/Service/HousesService.swift
+++ b/Roomie/Roomie/Network/Service/HousesService.swift
@@ -187,6 +187,5 @@ final class MockHousesService: HouseDetailServiceProtocol {
     func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>? {
         let mockData: PinnedResponseDTO = PinnedResponseDTO(isPinned: false)
         return BaseResponseBody(code: 200, message: "", data: mockData)
-
     }
 }

--- a/Roomie/Roomie/Network/Service/HousesService.swift
+++ b/Roomie/Roomie/Network/Service/HousesService.swift
@@ -65,3 +65,128 @@ extension HousesService: HouseDetailServiceProtocol {
         return try await self.request(with: .updatePinnedHouse(houseID: houseID))
     }
 }
+
+final class MockHousesService: HouseDetailServiceProtocol {
+    func fetchHouseDetailData(houseID: Int) async throws -> BaseResponseBody<HouseDetailResponseDTO>? {
+        let mockData: HouseDetailResponseDTO = HouseDetailResponseDTO(
+            houseInfo: HouseInfo(
+                houseID: 1,
+                name: "루미 100호점(이대역)",
+                mainImageURL: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F32%2Fab%2F6a%2F32ab6a8f37b33c4d7922505824a1af86.jpg&type=sc960_832",
+                monthlyRent: "43~50",
+                deposit: "90~100",
+                location: "서대문구 연희동",
+                occupancyTypes: "1,2,3인실",
+                occupancyStatus: "2/5",
+                genderPolicy: "여성전용",
+                contractTerm: 3,
+                moodTags: ["#차분한", "#유쾌한", "#경쾌한"],
+                roomMood: "전반적으로 조용하고 깔끔한 환경을 선호하는 아침형 룸메이트들이에요.",
+                groundRule: ["요리 후 바로 설거지해요", "청소는 주3회 돌아가면서 해요"],
+                maintenanceCost: 300000,
+                isPinned: true,
+                safetyLivingFacility: ["소화기", "소화기"],
+                kitchenFacility: ["주걱", "밥솥"]
+            ),
+            rooms: [
+                Room(
+                    roomID: 1,
+                    name: "1A 싱글침대",
+                    status: true,
+                    isTourAvailable: true,
+                    occupancyType: 2,
+                    gender: "여성",
+                    deposit: 5000000,
+                    prepaidUtilities: 100000,
+                    monthlyRent: 500000,
+                    contractPeriod: "24-12-20",
+                    managementFee: "1/n"
+                ),
+                Room(
+                    roomID: 1,
+                    name: "1A 싱글침대",
+                    status: false,
+                    isTourAvailable: true,
+                    occupancyType: 2,
+                    gender: "여성",
+                    deposit: 5000000,
+                    prepaidUtilities: 100000,
+                    monthlyRent: 500000,
+                    contractPeriod: "24-12-20",
+                    managementFee: "1/n"
+                ),
+                Room(
+                    roomID: 1,
+                    name: "1A 싱글침대",
+                    status: false,
+                    isTourAvailable: false,
+                    occupancyType: 2,
+                    gender: "여성",
+                    deposit: 5000000,
+                    prepaidUtilities: 100000,
+                    monthlyRent: 500000,
+                    contractPeriod: "24-12-20",
+                    managementFee: "1/n"
+                )
+            ],
+            roommates: [
+                Roommate(
+                    name: "1A 싱글침대",
+                    age: "20대 초반",
+                    job: "대학생",
+                    mbti: "INFP",
+                    sleepTime: "21:00 - 21:00",
+                    activityTime: "21:00 - 21:00"
+                )
+            ]
+        )
+        return BaseResponseBody(code: 200, message: "", data: mockData)
+    }
+    
+    func fetchHouseDetailImagesData(houseID: Int) async throws -> BaseResponseBody<HouseDetailImagesResponseDTO>? {
+        let mockData: HouseDetailImagesResponseDTO = HouseDetailImagesResponseDTO(
+            images: HouseDetailImages(
+                mainImageURL: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F32%2Fab%2F6a%2F32ab6a8f37b33c4d7922505824a1af86.jpg&type=sc960_832",
+                mainImageDescription: "상세설명",
+                facilityImageURLs: [
+                    "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F32%2Fab%2F6a%2F32ab6a8f37b33c4d7922505824a1af86.jpg&type=sc960_832",
+                    "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F32%2Fab%2F6a%2F32ab6a8f37b33c4d7922505824a1af86.jpg&type=sc960_832",
+                    "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F32%2Fab%2F6a%2F32ab6a8f37b33c4d7922505824a1af86.jpg&type=sc960_832"
+                ],
+                facilityImageDescription: "상세설명",
+                floorImageURL: "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F32%2Fab%2F6a%2F32ab6a8f37b33c4d7922505824a1af86.jpg&type=sc960_832"
+            )
+        )
+        return BaseResponseBody(code: 200, message: "", data: mockData)
+    }
+    
+    func fetchHouseDetailRoomsData(houseID: Int) async throws -> BaseResponseBody<HouseDetailRoomsResponseDTO>? {
+        let mockData: HouseDetailRoomsResponseDTO = HouseDetailRoomsResponseDTO(
+            rooms: [
+                HouseDetailRoom(
+                    roomID: 1,
+                    name: "1A 싱글침대",
+                    facility: ["침대, 책상, 옷"],
+                    status: true,
+                    mainImageURL: [
+                    "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F32%2Fab%2F6a%2F32ab6a8f37b33c4d7922505824a1af86.jpg&type=sc960_832",
+                    "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F32%2Fab%2F6a%2F32ab6a8f37b33c4d7922505824a1af86.jpg&type=sc960_832",
+                    "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F32%2Fab%2F6a%2F32ab6a8f37b33c4d7922505824a1af86.jpg&type=sc960_832"
+                    ]
+                )
+            ]
+        )
+        return BaseResponseBody(code: 200, message: "", data: mockData)
+    }
+    
+    func applyTour(request: TourRequestDTO, roomID: Int) async throws -> BaseResponseBody<TourResponseDTO>? {
+        let mockData: TourResponseDTO = TourResponseDTO(isSuccess: true)
+        return BaseResponseBody(code: 200, message: "", data: mockData)
+    }
+    
+    func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>? {
+        let mockData: PinnedResponseDTO = PinnedResponseDTO(isPinned: false)
+        return BaseResponseBody(code: 200, message: "", data: mockData)
+
+    }
+}

--- a/Roomie/Roomie/Presentation/HouseDetail/Component/RoomFacilityExpandView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/Component/RoomFacilityExpandView.swift
@@ -32,7 +32,7 @@ final class RoomFacilityExpandView: UIView {
     
     private let titleLabel = UILabel()
     
-    private let statusBackView = UIView()
+    private let statusContainerView = UIView()
     private let statusLabel = UILabel()
     
     private let chevronIcon = UIImageView()
@@ -89,7 +89,7 @@ final class RoomFacilityExpandView: UIView {
             $0.layer.cornerRadius = 8
         }
         
-        statusBackView.do {
+        statusContainerView.do {
             $0.backgroundColor = .grayscale3
             $0.layer.cornerRadius = 8
             $0.clipsToBounds = true
@@ -132,7 +132,7 @@ final class RoomFacilityExpandView: UIView {
     private func setUI() {
         addSubviews(
             titleLabel,
-            statusBackView,
+            statusContainerView,
             chevronIcon,
             expandButton,
             roomImageView,
@@ -140,7 +140,7 @@ final class RoomFacilityExpandView: UIView {
             oddStackView
         )
         
-        statusBackView.addSubview(statusLabel)
+        statusContainerView.addSubview(statusLabel)
     }
     
     private func setLayout() {
@@ -153,7 +153,7 @@ final class RoomFacilityExpandView: UIView {
             $0.leading.equalToSuperview().offset(14)
         }
         
-        statusBackView.snp.makeConstraints {
+        statusContainerView.snp.makeConstraints {
             $0.centerY.equalTo(titleLabel.snp.centerY)
             $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
             $0.height.equalTo(Screen.height(20))
@@ -226,7 +226,7 @@ private extension RoomFacilityExpandView {
         titleLabel.do {
             $0.setText(title, style: .body2, color: status ? .grayscale10 : .grayscale6)
         }
-        statusBackView.isHidden = status
+        statusContainerView.isHidden = status
         statusLabel.isHidden = status
     }
 }

--- a/Roomie/Roomie/Presentation/HouseDetail/View/Cell/RoomStatusTableViewCell.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/Cell/RoomStatusTableViewCell.swift
@@ -15,7 +15,7 @@ final class RoomStatusTableViewCell: BaseTableViewCell {
     
     // MARK: - UIComponent
     
-    private let backView = UIView()
+    private let containerView = UIView()
 
     private let statusView = RoomStatusView()
     
@@ -52,7 +52,7 @@ final class RoomStatusTableViewCell: BaseTableViewCell {
     // MARK: - UISetting
     
     override func setStyle() {
-        backView.do {
+        containerView.do {
             $0.layer.borderColor = UIColor.grayscale5.cgColor
             $0.layer.cornerRadius = 8
             $0.layer.borderWidth = 1
@@ -118,9 +118,9 @@ final class RoomStatusTableViewCell: BaseTableViewCell {
     }
     
     override func setUI() {
-        addSubview(backView)
+        addSubview(containerView)
         
-        backView.addSubviews(
+        containerView.addSubviews(
             statusView,
             chevronRightIcon,
             nameLabel,
@@ -144,7 +144,7 @@ final class RoomStatusTableViewCell: BaseTableViewCell {
     }
     
     override func setLayout() {
-        backView.snp.makeConstraints {
+        containerView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview().inset(12)

--- a/Roomie/Roomie/Presentation/HouseDetail/View/Cell/RoommateNotFoundTableViewCell.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/Cell/RoommateNotFoundTableViewCell.swift
@@ -14,14 +14,14 @@ final class RoommateNotFoundTableViewCell: BaseTableViewCell {
     
     // MARK: - UIComponent
     
-    private let backView = UIView()
+    private let containerView = UIView()
     
     private let titleLabel = UILabel()
     
     // MARK: - UISetting
     
     override func setStyle() {
-        backView.do {
+        containerView.do {
             $0.layer.borderColor = UIColor.grayscale5.cgColor
             $0.layer.cornerRadius = 8
             $0.layer.borderWidth = 1
@@ -34,13 +34,13 @@ final class RoommateNotFoundTableViewCell: BaseTableViewCell {
     }
     
     override func setUI() {
-        addSubview(backView)
+        addSubview(containerView)
         
-        backView.addSubview(titleLabel)
+        containerView.addSubview(titleLabel)
     }
     
     override func setLayout() {
-        backView.snp.makeConstraints {
+        containerView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview().inset(12)

--- a/Roomie/Roomie/Presentation/HouseDetail/View/Cell/RoommateTableViewCell.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/Cell/RoommateTableViewCell.swift
@@ -14,17 +14,17 @@ final class RoommateTableViewCell: BaseTableViewCell {
     
     // MARK: - UIComponent
     
-    private let backView = UIView()
+    private let containerView = UIView()
     
     private let profileImageView = UIImageView()
     
     private let ageLabel = UILabel()
     private let jobLabel = UILabel()
     
-    private let mbtiBackView = UIView()
+    private let mbtiContainerView = UIView()
     private let mbtiLabel = UILabel()
     
-    private let nameBackView = UIView()
+    private let nameContainerView = UIView()
     private let nameLabel = UILabel()
     
     private let sleepTimeTitleLabel = UILabel()
@@ -36,7 +36,7 @@ final class RoommateTableViewCell: BaseTableViewCell {
     // MARK: - UISetting
     
     override func setStyle() {
-        backView.do {
+        containerView.do {
             $0.layer.borderColor = UIColor.grayscale5.cgColor
             $0.layer.cornerRadius = 8
             $0.layer.borderWidth = 1
@@ -59,7 +59,7 @@ final class RoommateTableViewCell: BaseTableViewCell {
             $0.setText(style: .body2, color: .grayscale12)
         }
         
-        mbtiBackView.do {
+        mbtiContainerView.do {
             $0.backgroundColor = .grayscale4
             $0.layer.cornerRadius = 2
             $0.clipsToBounds = true
@@ -69,7 +69,7 @@ final class RoommateTableViewCell: BaseTableViewCell {
             $0.setText(style: .caption1, color: .grayscale8)
         }
         
-        nameBackView.do {
+        nameContainerView.do {
             $0.backgroundColor = .grayscale4
             $0.layer.cornerRadius = 2
             $0.clipsToBounds = true
@@ -97,27 +97,27 @@ final class RoommateTableViewCell: BaseTableViewCell {
     }
     
     override func setUI() {
-        addSubview(backView)
+        addSubview(containerView)
         
-        backView.addSubviews(
+        containerView.addSubviews(
             profileImageView,
             ageLabel,
             jobLabel,
-            mbtiBackView,
-            nameBackView,
+            mbtiContainerView,
+            nameContainerView,
             sleepTimeTitleLabel,
             sleepTimeLabel,
             activityTimeTitleLabel,
             activityTimeLabel
         )
         
-        mbtiBackView.addSubview(mbtiLabel)
+        mbtiContainerView.addSubview(mbtiLabel)
         
-        nameBackView.addSubview(nameLabel)
+        nameContainerView.addSubview(nameLabel)
     }
     
     override func setLayout() {
-        backView.snp.makeConstraints {
+        containerView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview().inset(12)
@@ -139,7 +139,7 @@ final class RoommateTableViewCell: BaseTableViewCell {
             $0.leading.equalTo(ageLabel.snp.trailing).offset(Screen.width(2))
         }
         
-        mbtiBackView.snp.makeConstraints {
+        mbtiContainerView.snp.makeConstraints {
             $0.leading.equalTo(jobLabel.snp.trailing).offset(8)
             $0.centerY.equalTo(jobLabel.snp.centerY)
         }
@@ -149,8 +149,8 @@ final class RoommateTableViewCell: BaseTableViewCell {
             $0.horizontalEdges.equalToSuperview().inset(4)
         }
         
-        nameBackView.snp.makeConstraints {
-            $0.leading.equalTo(mbtiBackView.snp.trailing).offset(4)
+        nameContainerView.snp.makeConstraints {
+            $0.leading.equalTo(mbtiContainerView.snp.trailing).offset(4)
             $0.centerY.equalTo(jobLabel.snp.centerY)
         }
         

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseAllPhotoView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseAllPhotoView.swift
@@ -19,13 +19,13 @@ final class HouseAllPhotoView: BaseView {
     
     // 대표시설
     private let mainTitleLabel = UILabel()
-    private let mainBackView = UIView()
+    private let mainContainerView = UIView()
     let mainImageView = UIImageView()
     let mainDescriptionLabel = UILabel()
     
     // 공용시설
     private let facilityTitleLabel = UILabel()
-    private let facilityBackView = UIView()
+    private let facilityContainerView = UIView()
     let facilityImageView = UIImageView()
     let facilityDescriptionLabel = UILabel()
     
@@ -35,7 +35,7 @@ final class HouseAllPhotoView: BaseView {
     
     // 평면도
     private let floorTitleLabel = UILabel()
-    private let floorBackView = UIView()
+    private let floorContainerView = UIView()
     let floorImageView = UIImageView()
     
     // MARK: - UISetting
@@ -45,7 +45,7 @@ final class HouseAllPhotoView: BaseView {
             $0.setText("대표사진", style: .heading5, color: .grayscale12)
         }
         
-        mainBackView.do {
+        mainContainerView.do {
             $0.layer.borderColor = UIColor.grayscale5.cgColor
             $0.layer.borderWidth = 1
             $0.layer.cornerRadius = 10
@@ -67,7 +67,7 @@ final class HouseAllPhotoView: BaseView {
             $0.setText("공용시설", style: .heading5, color: .grayscale12)
         }
         
-        facilityBackView.do {
+        facilityContainerView.do {
             $0.layer.borderColor = UIColor.grayscale5.cgColor
             $0.layer.borderWidth = 1
             $0.layer.cornerRadius = 10
@@ -100,7 +100,7 @@ final class HouseAllPhotoView: BaseView {
             $0.setText("평면도", style: .heading5, color: .grayscale12)
         }
         
-        floorBackView.do {
+        floorContainerView.do {
             $0.layer.borderColor = UIColor.grayscale5.cgColor
             $0.layer.borderWidth = 1
             $0.layer.cornerRadius = 10
@@ -120,20 +120,20 @@ final class HouseAllPhotoView: BaseView {
         scrollView.addSubview(contentView)
         contentView.addSubviews(
                 mainTitleLabel,
-                mainBackView,
+                mainContainerView,
                 facilityTitleLabel,
-                facilityBackView,
+                facilityContainerView,
                 roomTitleLabel,
                 roomStackView,
                 floorTitleLabel,
-                floorBackView
+                floorContainerView
             )
         
-        mainBackView.addSubviews(mainImageView, mainDescriptionLabel)
+        mainContainerView.addSubviews(mainImageView, mainDescriptionLabel)
         
-        facilityBackView.addSubviews(facilityImageView, facilityDescriptionLabel)
+        facilityContainerView.addSubviews(facilityImageView, facilityDescriptionLabel)
         
-        floorBackView.addSubview(floorImageView)
+        floorContainerView.addSubview(floorImageView)
     }
     
     override func setLayout() {
@@ -153,7 +153,7 @@ final class HouseAllPhotoView: BaseView {
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
         
-        mainBackView.snp.makeConstraints {
+        mainContainerView.snp.makeConstraints {
             $0.top.equalTo(mainTitleLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
@@ -170,11 +170,11 @@ final class HouseAllPhotoView: BaseView {
         }
         
         facilityTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(mainBackView.snp.bottom).offset(40)
+            $0.top.equalTo(mainContainerView.snp.bottom).offset(40)
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
         
-        facilityBackView.snp.makeConstraints {
+        facilityContainerView.snp.makeConstraints {
             $0.top.equalTo(facilityTitleLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
@@ -191,7 +191,7 @@ final class HouseAllPhotoView: BaseView {
         }
         
         roomTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(facilityBackView.snp.bottom).offset(40)
+            $0.top.equalTo(facilityContainerView.snp.bottom).offset(40)
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
         
@@ -205,7 +205,7 @@ final class HouseAllPhotoView: BaseView {
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
         
-        floorBackView.snp.makeConstraints {
+        floorContainerView.snp.makeConstraints {
             $0.top.equalTo(floorTitleLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview().inset(24)

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
@@ -18,6 +18,7 @@ final class HouseDetailView: BaseView {
     private let contentView = UIView()
     
     // HousePhoto Section
+    let photoBackView = UIView()
     let photoImageView = UIImageView()
     
     // HouseInfo Section
@@ -196,7 +197,7 @@ final class HouseDetailView: BaseView {
         scrollView.addSubviews(contentView)
         
         contentView.addSubviews(
-            photoImageView,
+            photoBackView,
             houseInfoBackView,
             nameBackView,
             titleLabel,
@@ -214,6 +215,8 @@ final class HouseDetailView: BaseView {
             roommateTitleLabel,
             roommateTableView
         )
+        
+        photoBackView.addSubview(photoImageView)
         
         nameBackView.addSubview(nameLabel)
         
@@ -251,19 +254,24 @@ final class HouseDetailView: BaseView {
             $0.height.greaterThanOrEqualToSuperview().priority(.low)
         }
         
-        photoImageView.snp.makeConstraints {
+        photoBackView.snp.makeConstraints {
             $0.top.horizontalEdges.equalToSuperview()
             $0.height.equalTo(Screen.height(316))
         }
         
+        photoImageView.snp.makeConstraints {
+            $0.top.equalTo(self.snp.top).priority(.high)
+            $0.horizontalEdges.bottom.equalToSuperview()
+        }
+        
         houseInfoBackView.snp.makeConstraints {
-            $0.top.equalTo(photoImageView.snp.bottom).offset(-20)
+            $0.top.equalTo(photoBackView.snp.bottom).offset(-20)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalTo(lookInsidePhotoButton.snp.bottom).offset(20)
         }
         
         nameBackView.snp.makeConstraints {
-            $0.top.equalTo(photoImageView.snp.bottom)
+            $0.top.equalTo(photoBackView.snp.bottom)
             $0.leading.equalToSuperview().inset(20)
         }
         

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseDetailView.swift
@@ -18,12 +18,12 @@ final class HouseDetailView: BaseView {
     private let contentView = UIView()
     
     // HousePhoto Section
-    let photoBackView = UIView()
+    let photoContainerView = UIView()
     let photoImageView = UIImageView()
     
     // HouseInfo Section
-    private let houseInfoBackView = UIView()
-    private let nameBackView = UIView()
+    private let houseInfoContainerView = UIView()
+    private let nameContainerView = UIView()
     let nameLabel = UILabel()
     let titleLabel = UILabel()
     let locationIconLabel = HouseInfoIconLabel(houseInfoType: .location)
@@ -38,7 +38,7 @@ final class HouseDetailView: BaseView {
     
     // roomMood Section
     private let roomMoodTitleLabel = UILabel()
-    private let roomMoodBackView = UIView()
+    private let roomMoodContainerView = UIView()
     let roomMoodLabel = UILabel()
     private let moodTagsStackView = UIStackView()
     private let roomMoodSeparatorView = UIView()
@@ -60,7 +60,7 @@ final class HouseDetailView: BaseView {
     let roommateTableView = UITableView()
     
     // bottom Button
-    private let bottomButtonbackView = UIView()
+    private let bottomButtonContainerView = UIView()
     private let bottomButtonSeparatorView = UIView()
     let wishListButton = RoomieIconButton(imageName: "icn_heart_24_normal", border: true)
     let contactButton = RoomieIconButton(imageName: "icn_inquire_24", border: true)
@@ -79,12 +79,12 @@ final class HouseDetailView: BaseView {
             $0.clipsToBounds = true
         }
         
-        houseInfoBackView.do {
+        houseInfoContainerView.do {
             $0.backgroundColor = .grayscale1
             $0.roundCorners(cornerRadius: 16, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         }
         
-        nameBackView.do {
+        nameContainerView.do {
             $0.backgroundColor = .primaryLight5
             $0.layer.cornerRadius = 4
             $0.layer.borderWidth = 1
@@ -122,7 +122,7 @@ final class HouseDetailView: BaseView {
             $0.setText("룸 분위기", style: .heading5, color: .grayscale12)
         }
         
-        roomMoodBackView.do {
+        roomMoodContainerView.do {
             $0.backgroundColor = .grayscale1
             $0.layer.borderColor = UIColor.grayscale5.cgColor
             $0.layer.borderWidth = 1
@@ -182,7 +182,7 @@ final class HouseDetailView: BaseView {
             $0.separatorStyle = .none
         }
 
-        bottomButtonbackView.do {
+        bottomButtonContainerView.do {
             $0.backgroundColor = .grayscale1
         }
         
@@ -192,14 +192,14 @@ final class HouseDetailView: BaseView {
     }
     
     override func setUI() {
-        addSubviews(scrollView, bottomButtonbackView)
+        addSubviews(scrollView, bottomButtonContainerView)
         
         scrollView.addSubviews(contentView)
         
         contentView.addSubviews(
-            photoBackView,
-            houseInfoBackView,
-            nameBackView,
+            photoContainerView,
+            houseInfoContainerView,
+            nameContainerView,
             titleLabel,
             firstIconLabelStackView,
             secondIconLabelStackView,
@@ -207,7 +207,7 @@ final class HouseDetailView: BaseView {
             lookInsidePhotoButton,
             houseInfoSeparatorView,
             roomMoodTitleLabel,
-            roomMoodBackView,
+            roomMoodContainerView,
             roomStatusTitleLabel,
             roomStatusTableView,
             facilityTitleLabel,
@@ -216,15 +216,15 @@ final class HouseDetailView: BaseView {
             roommateTableView
         )
         
-        photoBackView.addSubview(photoImageView)
+        photoContainerView.addSubview(photoImageView)
         
-        nameBackView.addSubview(nameLabel)
+        nameContainerView.addSubview(nameLabel)
         
         firstIconLabelStackView.addArrangedSubviews(locationIconLabel, occupancyTypesIconLabel)
         
         secondIconLabelStackView.addArrangedSubviews(occupancyStatusIconLabel, genderPolicyIconLabel)
         
-        roomMoodBackView.addSubviews(
+        roomMoodContainerView.addSubviews(
             roomMoodLabel,
             moodTagsStackView,
             roomMoodSeparatorView,
@@ -234,7 +234,7 @@ final class HouseDetailView: BaseView {
         
         facilityStackView.addArrangedSubviews(safetyLivingFacilityView, kitchenFacilityView)
         
-        bottomButtonbackView.addSubviews(
+        bottomButtonContainerView.addSubviews(
             bottomButtonSeparatorView,
             wishListButton,
             contactButton,
@@ -245,7 +245,7 @@ final class HouseDetailView: BaseView {
     override func setLayout() {
         scrollView.snp.makeConstraints {
             $0.top.horizontalEdges.equalToSuperview()
-            $0.bottom.equalTo(bottomButtonbackView.snp.top)
+            $0.bottom.equalTo(bottomButtonContainerView.snp.top)
         }
         
         contentView.snp.makeConstraints {
@@ -254,7 +254,7 @@ final class HouseDetailView: BaseView {
             $0.height.greaterThanOrEqualToSuperview().priority(.low)
         }
         
-        photoBackView.snp.makeConstraints {
+        photoContainerView.snp.makeConstraints {
             $0.top.horizontalEdges.equalToSuperview()
             $0.height.equalTo(Screen.height(316))
         }
@@ -264,14 +264,14 @@ final class HouseDetailView: BaseView {
             $0.horizontalEdges.bottom.equalToSuperview()
         }
         
-        houseInfoBackView.snp.makeConstraints {
-            $0.top.equalTo(photoBackView.snp.bottom).offset(-20)
+        houseInfoContainerView.snp.makeConstraints {
+            $0.top.equalTo(photoContainerView.snp.bottom).offset(-20)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalTo(lookInsidePhotoButton.snp.bottom).offset(20)
         }
         
-        nameBackView.snp.makeConstraints {
-            $0.top.equalTo(photoBackView.snp.bottom)
+        nameContainerView.snp.makeConstraints {
+            $0.top.equalTo(photoContainerView.snp.bottom)
             $0.leading.equalToSuperview().inset(20)
         }
         
@@ -281,7 +281,7 @@ final class HouseDetailView: BaseView {
         }
         
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(nameBackView.snp.bottom).offset(8)
+            $0.top.equalTo(nameContainerView.snp.bottom).offset(8)
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
         
@@ -318,7 +318,7 @@ final class HouseDetailView: BaseView {
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
         
-        roomMoodBackView.snp.makeConstraints {
+        roomMoodContainerView.snp.makeConstraints {
             $0.top.equalTo(roomMoodTitleLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
@@ -353,7 +353,7 @@ final class HouseDetailView: BaseView {
         }
         
         roomStatusTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(roomMoodBackView.snp.bottom).offset(48)
+            $0.top.equalTo(roomMoodContainerView.snp.bottom).offset(48)
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
         
@@ -385,7 +385,7 @@ final class HouseDetailView: BaseView {
             $0.bottom.equalToSuperview().inset(8)
         }
         
-        bottomButtonbackView.snp.makeConstraints {
+        bottomButtonContainerView.snp.makeConstraints {
             $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(Screen.height(80))

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseDetailViewController.swift
@@ -89,8 +89,6 @@ final class HouseDetailViewController: BaseViewController {
         super.viewDidLayoutSubviews()
         
         rootView.updateRoomStatusTableViewHeight(viewModel.roomInfos.count, height: roomStatusCellHeight)
-        rootView.roomStatusTableView.layoutIfNeeded()
-        
         rootView.updateRoommateTableViewHeight(viewModel.roommateInfos.count, height: roommateCellHeight)
     }
     
@@ -269,8 +267,7 @@ private extension HouseDetailViewController {
         case .filled:
             setFilledNavigationBar()
         case .filledWithTitle:
-            setFilledNavigationBar()
-            navigationItem.title = navigationBarTitle
+            setFilledNavigationBar(navigationBarTitle)
         }
     }
     
@@ -300,7 +297,9 @@ private extension HouseDetailViewController {
         navigationItem.title = nil
     }
     
-    func setFilledNavigationBar() {
+    func setFilledNavigationBar(_ navigationBarTitle: String = "") {
+        navigationItem.title = navigationBarTitle
+        
         navigationController?.navigationBar.isHidden = false
         
         let filledAppearance = UINavigationBarAppearance()
@@ -352,7 +351,7 @@ extension HouseDetailViewController: UITableViewDataSource {
         
         if tableView == rootView.roommateTableView {
             let cellCount = viewModel.roommateInfos.count == 0 ? 1 : viewModel.roommateInfos.count
-            return cellCount // TODO: DataBind
+            return cellCount
         }
         
         return 0
@@ -443,14 +442,15 @@ extension HouseDetailViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y
         
+        let newStatus: NavigationBarStatus
         if offsetY > navigationBarThreshold {
-            if offsetY > navigationTitleThreshold {
-                navigationBarStatus = .filledWithTitle
-            } else {
-                navigationBarStatus = .filled
-            }
+            newStatus = offsetY > navigationTitleThreshold ? .filledWithTitle : .filled
         } else {
-            navigationBarStatus = .clear
+            newStatus = .clear
+        }
+
+        if navigationBarStatus != newStatus {
+            navigationBarStatus = newStatus
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #152 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 미루고 미루던 Stretch Header를 구현했어요..ㅎ

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| stretch header | <img src = "https://github.com/user-attachments/assets/3b4642e0-e04a-4441-819c-03d67f58ba4e" width ="250"> | <img src = "https://github.com/user-attachments/assets/ae0fa707-f64f-4c42-afbe-e6e3d9c71217" width ="250"> |



## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 어떻게 구현했을까?

- 처음에 스크롤했을 때 `offsetY`가 0보다 작아지면 `UIImageView`의 높이를 동적으로 계산하는 방법을 사용하려고 했는데
- 스크롤 한 번에 너무 많은 계산이 필요하기 때문에 좋은 방법은 아니라고 판단했습니다람쥐
- 그래서 저는 기존 `UIImageView`위치에 `UIView`를 하나 깔고 `UIImageView`의 `horizontalEdges` 와 `bottom`을 이 `UIView`에 맞추고 `top`을 `self.snp.top`에 걸어 스크롤 했을 때 자동으로 `UIImageView`가 늘어나도록 구현했어요
- 코드를 보면 바로 이해 가능

<details>
<summary>HouseDetailView.swift</summary>

```swift
contentView.addSubviews(
            photoBackView, ...

photoBackView.addSubview(photoImageView)
```
</details>

`photoBackView`위에 `photoImageView`를 올리고

<details>
<summary>HouseDetailView.swift</summary>

```swift
photoBackView.snp.makeConstraints {
            $0.top.horizontalEdges.equalToSuperview()
            $0.height.equalTo(Screen.height(316))
        }
        
        photoImageView.snp.makeConstraints {
            $0.top.equalTo(self.snp.top).priority(.high)
            $0.horizontalEdges.bottom.equalToSuperview()
        }
```
</details>

이렇게 `photoImageView`의 `top`만 따로 빼서 고정시켰습니다

`$0.top.equalTo(self.snp.top).priority(.high)` 를 사용한 이유는 다음과 같습니다!
- 기본으로 제약조건 우선순위는 `.required`로 적용되고, `top`의 우선순위를 `.high`로 한단계 낮추어
- 높이가 동적으로 변경될 때 우선순위가 더 높은 `bottom`이 제약조건이 적용되어 `top`제약조건을 유연하게 조정하기 위함!
- `.low`로 하면 우선순위가 너무 낮아서 **UIKit**이 높이를 결정할 때 이를 무시한다고 하네요.


## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

- 근데 `develop`에 머지하면 되는 거 맞죠...?? 기억이 가물가물치..
