### PR TITLE
[feat/#156] 상세 매물 이미지 페이지 토글 & 가로 스크롤 구현

### DIFF
--- a/Roomie/Roomie/Presentation/HouseDetail/Component/ImageHorizontalScrollView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/Component/ImageHorizontalScrollView.swift
@@ -61,6 +61,8 @@ final class ImageHorizontalScrollView: UIView {
             $0.backgroundColor = .white
             $0.isPagingEnabled = true
             $0.showsHorizontalScrollIndicator = false
+            $0.layer.cornerRadius = 8
+            $0.clipsToBounds = true
         }
         
         stackView.do {
@@ -130,6 +132,7 @@ extension ImageHorizontalScrollView {
                 
                 imageView.snp.makeConstraints {
                     $0.width.equalTo(scrollView.snp.width)
+                    $0.height.equalTo(scrollView.snp.height)
                 }
             }
         }
@@ -142,5 +145,9 @@ extension ImageHorizontalScrollView: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let index = Int(scrollView.contentOffset.x / scrollView.frame.width)
         currentPage = index + 1
+        
+        if scrollView.contentOffset.y != 0 {
+            scrollView.contentOffset.y = 0
+        }
     }
 }

--- a/Roomie/Roomie/Presentation/HouseDetail/Component/ImageHorizontalScrollView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/Component/ImageHorizontalScrollView.swift
@@ -13,7 +13,7 @@ import Kingfisher
 import SnapKit
 import Then
 
-class ImageHorizontalScrollView: UIView {
+final class ImageHorizontalScrollView: UIView {
     
     // MARK: - Property
     
@@ -78,9 +78,8 @@ class ImageHorizontalScrollView: UIView {
     }
     
     private func setUI() {
-        addSubview(scrollView)
-        addSubview(pageContainerView)
-        scrollView.addSubviews(stackView)
+        addSubviews(scrollView, pageContainerView)
+        scrollView.addSubview(stackView)
         pageContainerView.addSubview(pageCountLabel)
     }
     

--- a/Roomie/Roomie/Presentation/HouseDetail/Component/ImageHorizontalScrollView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/Component/ImageHorizontalScrollView.swift
@@ -1,0 +1,92 @@
+//
+//  ImageHorizontalScrollView.swift
+//  Roomie
+//
+//  Created by 김승원 on 3/13/25.
+//
+
+import UIKit
+import Combine
+
+import CombineCocoa
+import Kingfisher
+import SnapKit
+import Then
+
+class ImageHorizontalScrollView: UIView {
+    
+    // MARK: - UIComponent
+    
+    private let scrollView = UIScrollView()
+    private let stackView = UIStackView()
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setStyle()
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - UISetting
+    
+    private func setStyle() {
+        scrollView.do {
+            $0.backgroundColor = .grayscale5
+            $0.isPagingEnabled = true
+            $0.showsHorizontalScrollIndicator = false
+        }
+        
+        stackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 0
+            $0.alignment = .fill
+            $0.distribution = .fillEqually
+        }
+        
+    }
+    
+    private func setUI() {
+        addSubview(scrollView)
+        scrollView.addSubview(stackView)
+    }
+    
+    private func setLayout() {
+        scrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.height.equalToSuperview()
+            $0.width.greaterThanOrEqualToSuperview().priority(.low)
+        }
+    }
+}
+
+extension ImageHorizontalScrollView {
+    func setImages(imageURLs: [String]) {
+        for imageURL in imageURLs {
+            if let imageURL = URL(string: imageURL) {
+                let imageView = UIImageView()
+                
+                imageView.do {
+                    $0.kf.setImage(with: imageURL)
+                    $0.contentMode = .scaleAspectFill
+                    $0.clipsToBounds = true
+                    stackView.addArrangedSubview($0)
+                }
+                
+                imageView.snp.makeConstraints {
+                    $0.width.equalTo(scrollView.snp.width)
+                }
+            }
+        }
+    }
+}

--- a/Roomie/Roomie/Presentation/HouseDetail/Component/ImageHorizontalScrollView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/Component/ImageHorizontalScrollView.swift
@@ -15,10 +15,25 @@ import Then
 
 class ImageHorizontalScrollView: UIView {
     
+    // MARK: - Property
+    
+    private var currentPage: Int = 1 {
+        didSet {
+            pageCountLabel.do {
+                $0.updateText("\(currentPage)/\(totalPage)")
+            }
+        }
+    }
+    
+    private var totalPage: Int = 1
+    
     // MARK: - UIComponent
     
     private let scrollView = UIScrollView()
     private let stackView = UIStackView()
+    
+    private let pageContainerView = UIView()
+    private let pageCountLabel = UILabel()
     
     // MARK: - Initializer
     
@@ -28,17 +43,22 @@ class ImageHorizontalScrollView: UIView {
         setStyle()
         setUI()
         setLayout()
+        setDelegate()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
+    private func setDelegate() {
+        scrollView.delegate = self
+    }
+    
     // MARK: - UISetting
     
     private func setStyle() {
         scrollView.do {
-            $0.backgroundColor = .grayscale5
+            $0.backgroundColor = .white
             $0.isPagingEnabled = true
             $0.showsHorizontalScrollIndicator = false
         }
@@ -50,11 +70,18 @@ class ImageHorizontalScrollView: UIView {
             $0.distribution = .fillEqually
         }
         
+        pageContainerView.do {
+            $0.backgroundColor = .transpGray1250
+            $0.layer.cornerRadius = 11
+            $0.clipsToBounds = true
+        }
     }
     
     private func setUI() {
         addSubview(scrollView)
-        scrollView.addSubview(stackView)
+        addSubview(pageContainerView)
+        scrollView.addSubviews(stackView)
+        pageContainerView.addSubview(pageCountLabel)
     }
     
     private func setLayout() {
@@ -67,12 +94,31 @@ class ImageHorizontalScrollView: UIView {
             $0.height.equalToSuperview()
             $0.width.greaterThanOrEqualToSuperview().priority(.low)
         }
+        
+        pageContainerView.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(8)
+            $0.bottom.equalToSuperview().inset(8)
+            $0.width.equalTo(Screen.width(35))
+            $0.height.equalTo(Screen.height(22))
+        }
+        
+        pageCountLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
     }
 }
 
+// MARK: - Functions
+
 extension ImageHorizontalScrollView {
-    func setImages(imageURLs: [String]) {
-        for imageURL in imageURLs {
+    func setImages(urlStrings: [String]) {
+        self.totalPage = urlStrings.count
+        
+        pageCountLabel.do {
+            $0.setText("\(currentPage)/\(totalPage)", style: .caption3, color: .grayscale1)
+        }
+        
+        for imageURL in urlStrings {
             if let imageURL = URL(string: imageURL) {
                 let imageView = UIImageView()
                 
@@ -88,5 +134,14 @@ extension ImageHorizontalScrollView {
                 }
             }
         }
+    }
+}
+
+// MARK: - UIScrollViewDelegate
+
+extension ImageHorizontalScrollView: UIScrollViewDelegate {
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        let index = Int(scrollView.contentOffset.x / scrollView.frame.width)
+        currentPage = index + 1
     }
 }

--- a/Roomie/Roomie/Presentation/HouseDetail/Component/ImageHorizontalScrollView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/Component/ImageHorizontalScrollView.swift
@@ -139,7 +139,7 @@ extension ImageHorizontalScrollView {
 // MARK: - UIScrollViewDelegate
 
 extension ImageHorizontalScrollView: UIScrollViewDelegate {
-    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let index = Int(scrollView.contentOffset.x / scrollView.frame.width)
         currentPage = index + 1
     }

--- a/Roomie/Roomie/Presentation/HouseDetail/Component/RoomFacilityExpandView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/Component/RoomFacilityExpandView.swift
@@ -105,10 +105,6 @@ final class RoomFacilityExpandView: UIView {
         }
         
         roomImageScrollView.do {
-            $0.backgroundColor = .grayscale5
-            $0.contentMode = .scaleAspectFill
-            $0.layer.cornerRadius = 8
-            $0.clipsToBounds = true
             $0.isHidden = true
         }
         

--- a/Roomie/Roomie/Presentation/HouseDetail/Component/RoomFacilityExpandView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/Component/RoomFacilityExpandView.swift
@@ -39,7 +39,7 @@ final class RoomFacilityExpandView: UIView {
     
     private let expandButton = UIButton()
     
-    private let roomImageView = UIImageView()
+    private let roomImageScrollView = ImageHorizontalScrollView()
     
     private let evenStackView = UIStackView()
     private let oddStackView = UIStackView()
@@ -104,7 +104,7 @@ final class RoomFacilityExpandView: UIView {
             $0.contentMode = .scaleAspectFit
         }
         
-        roomImageView.do {
+        roomImageScrollView.do {
             $0.backgroundColor = .grayscale5
             $0.contentMode = .scaleAspectFill
             $0.layer.cornerRadius = 8
@@ -135,7 +135,7 @@ final class RoomFacilityExpandView: UIView {
             statusContainerView,
             chevronIcon,
             expandButton,
-            roomImageView,
+            roomImageScrollView,
             evenStackView,
             oddStackView
         )
@@ -176,20 +176,20 @@ final class RoomFacilityExpandView: UIView {
             $0.height.equalTo(Screen.height(56))
         }
         
-        roomImageView.snp.makeConstraints {
+        roomImageScrollView.snp.makeConstraints {
             $0.top.equalTo(expandButton.snp.bottom)
             $0.horizontalEdges.equalToSuperview().inset(8)
             $0.height.equalTo(Screen.height(192))
         }
         
         evenStackView.snp.makeConstraints {
-            $0.top.equalTo(roomImageView.snp.bottom).offset(12)
+            $0.top.equalTo(roomImageScrollView.snp.bottom).offset(12)
             $0.leading.equalToSuperview().inset(8)
             $0.width.equalTo(Screen.width(155))
         }
         
         oddStackView.snp.makeConstraints {
-            $0.top.equalTo(roomImageView.snp.bottom).offset(12)
+            $0.top.equalTo(roomImageScrollView.snp.bottom).offset(12)
             $0.trailing.equalToSuperview().inset(8)
             $0.width.equalTo(Screen.width(155))
         }
@@ -211,7 +211,7 @@ private extension RoomFacilityExpandView {
     private func updateView() {
         oddStackView.isHidden = !isExpanded
         evenStackView.isHidden = !isExpanded
-        roomImageView.isHidden = !isExpanded
+        roomImageScrollView.isHidden = !isExpanded
         
         self.snp.updateConstraints {
             $0.height.equalTo(Screen.height(isExpanded ? expandedHeight : unExpandedHeight))
@@ -252,10 +252,8 @@ extension RoomFacilityExpandView {
         }
     }
     
-    func configure(_ urlString: String) {
-        if let roomImageURL = URL(string: urlString) {
-            roomImageView.kf.setImage(with: roomImageURL)
-        }
+    func configure(_ urlStrings: [String]) {
+        roomImageScrollView.setImages(urlStrings: urlStrings)
     }
     
     func setExpanded(_ isExpanded: Bool) {

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseAllPhotoView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseAllPhotoView.swift
@@ -26,7 +26,7 @@ final class HouseAllPhotoView: BaseView {
     // 공용시설
     private let facilityTitleLabel = UILabel()
     private let facilityContainerView = UIView()
-    let facilityImageView = UIImageView()
+    let facilityImageScrollView = ImageHorizontalScrollView()
     let facilityDescriptionLabel = UILabel()
     
     // 각 방 시설
@@ -74,8 +74,7 @@ final class HouseAllPhotoView: BaseView {
             $0.clipsToBounds = true
         }
         
-        facilityImageView.do {
-            $0.backgroundColor = .grayscale5
+        facilityImageScrollView.do {
             $0.contentMode = .scaleAspectFill
             $0.layer.cornerRadius = 8
             $0.clipsToBounds = true
@@ -118,6 +117,7 @@ final class HouseAllPhotoView: BaseView {
     override func setUI() {
         addSubview(scrollView)
         scrollView.addSubview(contentView)
+        
         contentView.addSubviews(
                 mainTitleLabel,
                 mainContainerView,
@@ -130,9 +130,7 @@ final class HouseAllPhotoView: BaseView {
             )
         
         mainContainerView.addSubviews(mainImageView, mainDescriptionLabel)
-        
-        facilityContainerView.addSubviews(facilityImageView, facilityDescriptionLabel)
-        
+        facilityContainerView.addSubviews(facilityImageScrollView, facilityDescriptionLabel)
         floorContainerView.addSubview(floorImageView)
     }
     
@@ -179,13 +177,13 @@ final class HouseAllPhotoView: BaseView {
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
         
-        facilityImageView.snp.makeConstraints {
+        facilityImageScrollView.snp.makeConstraints {
             $0.top.horizontalEdges.equalToSuperview().inset(8)
             $0.height.equalTo(Screen.height(192))
         }
         
         facilityDescriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(facilityImageView.snp.bottom).offset(8)
+            $0.top.equalTo(facilityImageScrollView.snp.bottom).offset(8)
             $0.horizontalEdges.equalToSuperview().inset(8)
             $0.bottom.equalToSuperview().inset(12)
         }
@@ -221,13 +219,15 @@ final class HouseAllPhotoView: BaseView {
 extension HouseAllPhotoView {
     func fetchRooms(_ rooms: [HouseDetailRoom]) {
         roomStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        
         for index in 0..<rooms.count {
             let expendView = RoomFacilityExpandView(
                 title: rooms[index].name,
                 status: rooms[index].status
             )
             expendView.dataBind(rooms[index].facility)
-            expendView.configure(rooms[index].mainImageURL[0])
+            expendView.configure(rooms[index].mainImageURL)
+            
             roomStackView.addArrangedSubview(expendView)
         }
     }

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseAllPhotoView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseAllPhotoView.swift
@@ -74,12 +74,6 @@ final class HouseAllPhotoView: BaseView {
             $0.clipsToBounds = true
         }
         
-        facilityImageScrollView.do {
-            $0.contentMode = .scaleAspectFill
-            $0.layer.cornerRadius = 8
-            $0.clipsToBounds = true
-        }
-        
         facilityDescriptionLabel.do {
             $0.setText(style: .body4, color: .grayscale12)
         }

--- a/Roomie/Roomie/Presentation/HouseDetail/View/HouseSinglePhotoView.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/View/HouseSinglePhotoView.swift
@@ -69,6 +69,7 @@ final class HouseSinglePhotoView: BaseView {
 extension HouseSinglePhotoView {
     func fetchRooms(_ rooms: [HouseDetailRoom], with expandIndex: Int) {
         roomStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        
         for index in 0..<rooms.count {
             let isexpanded = (index == expandIndex)
             
@@ -77,8 +78,9 @@ extension HouseSinglePhotoView {
                 status: rooms[index].status
             )
             expandedView.dataBind(rooms[index].facility)
-            expandedView.configure(rooms[index].mainImageURL[0])
+            expandedView.configure(rooms[index].mainImageURL)
             expandedView.setExpanded(isexpanded)
+            
             roomStackView.addArrangedSubview(expandedView)
         }
     }

--- a/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseAllPhotoViewController.swift
+++ b/Roomie/Roomie/Presentation/HouseDetail/ViewController/HouseAllPhotoViewController.swift
@@ -77,9 +77,8 @@ private extension HouseAllPhotoViewController {
                 }
                 rootView.mainDescriptionLabel
                     .updateText(houseDetailImagesData.images.mainImageDescription)
-                if let facilityImageURL = URL(string: houseDetailImagesData.images.facilityImageURLs[0]) {
-                    self.rootView.facilityImageView.kf.setImage(with: facilityImageURL)
-                }
+                rootView.facilityImageScrollView
+                    .setImages(urlStrings: houseDetailImagesData.images.facilityImageURLs)
                 rootView.facilityDescriptionLabel
                     .updateText(houseDetailImagesData.images.facilityImageDescription)
                 if let floorImageURL = URL(string: houseDetailImagesData.images.floorImageURL) {


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #156 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 앱잼 때 미뤘던 상세 매물 이미지 뷰에서 가로 스크롤을 구현했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 야호 | <img src = "https://github.com/user-attachments/assets/a76791f6-6e72-4378-a056-b0906a1e7370" width ="250"> | <img src = "https://github.com/user-attachments/assets/9f0b8ad7-23b3-4ce2-aaa3-de69c1a5f683" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 역시 UIStackView는 짱이야

- 가로 스크롤 구현 생각에 무작정 UICollectionView를 써야하나 했는데
- 방의 개수가 동적으로 변하기 때문에 UICollectionView를 동적으로 생성하는 건... 좀 아닌 거 같죠
- 또 재사용 셀이 굳이 필요 없다고 생각이 들어서
- UIScrollView 위에 UIStackView를 올린 컴포넌트를 따로 빼서 구현했습니다ㅏㅏ

<details>
<summary>ImageHorizontalScrollView.swift</summary>

```swift
extension ImageHorizontalScrollView {
    func setImages(urlStrings: [String]) {
        self.totalPage = urlStrings.count
        
        pageCountLabel.do {
            $0.setText("\(currentPage)/\(totalPage)", style: .caption3, color: .grayscale1)
        }
        
        for imageURL in urlStrings {
            if let imageURL = URL(string: imageURL) {
                let imageView = UIImageView()
                
                imageView.do {
                    $0.kf.setImage(with: imageURL)
                    $0.contentMode = .scaleAspectFill
                    $0.clipsToBounds = true
                    stackView.addArrangedSubview($0)
                }
                
                imageView.snp.makeConstraints {
                    $0.width.equalTo(scrollView.snp.width)
                }
            }
        }
    }
}
```
</details>

- 스크롤뷰 위에 스택뷰를 올리고 위 함수를 통해 url 배열을 받아 동적으로 스택뷰에 할당!

### 페이징 기능은요?

- UIScrollViewDelegate를 사용해서 구현했어요!

<details>
<summary>ImageHorizontalScrollView.swift</summary>

```swift
// MARK: - UIScrollViewDelegate

extension ImageHorizontalScrollView: UIScrollViewDelegate {
    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
        let index = Int(scrollView.contentOffset.x / scrollView.frame.width)
        currentPage = index + 1
    }
}
```
</details>

- 스크롤 뷰가 감속을 끝냈을 때 호출되는 함수입니다. 즉 스크롤이 끝났을 때 호출되는 함수
- 스크롤이 멈춘 시점에 스크롤뷰 너비를 현재 스크롤된 가로 위치를 나누어 페이지를 계산하도록 했습니다!
- 아 그리고 스크롤뷰에 `.isPagingEnabled = true`기능이 있더라고요 그래서 알아서 딱딱 달라붙습니다 

=> 현재 `scrollViewDidEndDecelerating`에서 `scrollViewDidScroll`함수로 수정했습니다! 더 부드러운 페이징이 가능하네요!
- 실기기에서 스크롤을 빠르게 연속으로 하면, 마지막 페이지가 다 되어서야 페이지 수가 변하더라고요

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

현재 default 브랜치가 `main`으로 되어있던데, 자꾸 main에 실수로 머지할 거 같아요..ㅎ
혹시 `develop`브랜치를 default로 해두는 것에 어떻게 생각하시는지 궁금합니다
